### PR TITLE
Update dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,14 +18,14 @@ dependencies:
   args: ^2.0.0
   collection: ^1.16.0
   crypto: ^3.0.0
-  file: ^7.0.0
+  file: '>=6.0.0 <8.0.0'
   glob: ^2.0.1
   html: ^0.15.0
   http: ^1.1.0
   meta: ^1.7.0
   path: ^1.8.0
   platform: ^3.1.0 # overridden for lowest versions compatibility
-  pub_updater: ^0.4.0
+  pub_updater: '>=0.3.0 <0.5.0'
   source_span: ^1.10.0
   uuid: ^4.1.0
   xml: ">=5.3.0 <7.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,14 +18,14 @@ dependencies:
   args: ^2.0.0
   collection: ^1.16.0
   crypto: ^3.0.0
-  file: ^6.0.0
+  file: ^7.0.0
   glob: ^2.0.1
   html: ^0.15.0
   http: ^1.1.0
   meta: ^1.7.0
   path: ^1.8.0
   platform: ^3.1.0 # overridden for lowest versions compatibility
-  pub_updater: ^0.3.0
+  pub_updater: ^0.4.0
   source_span: ^1.10.0
   uuid: ^4.1.0
   xml: ">=5.3.0 <7.0.0"


### PR DESCRIPTION
In the newer Flutter versions(3.19 in my case), it is not possible to build the app due to [File](https://pub.dev/packages/file/changelog) dependency.  