### PR TITLE
Skip named types used in Widget State class declarations

### DIFF
--- a/lib/src/analyzers/unused_code_analyzer/used_code_visitor.dart
+++ b/lib/src/analyzers/unused_code_analyzer/used_code_visitor.dart
@@ -97,6 +97,9 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitNamedType(NamedType node) {
+    if (_isUsedInWidgetStateClassDeclaration(node)) {
+      return;
+    }
     _recordPrefixedElement(node.importPrefix, node.element);
     super.visitNamedType(node);
   }
@@ -243,5 +246,15 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
 
     return grandGrandParent is NamedType &&
         isWidgetStateOrSubclass(grandGrandParent.type);
+  }
+
+  bool _isUsedInWidgetStateClassDeclaration(NamedType namedType) {
+    final parent = namedType.parent;
+    if (parent is TypeArgumentList) {
+      final grandParent = parent.parent;
+      return grandParent is NamedType &&
+          isWidgetStateOrSubclass(grandParent.type);
+    }
+    return false;
   }
 }


### PR DESCRIPTION
Added a check in visitNamedType to skip named types if they are used in Widget State class declarations. This prevents these specific named types from being recorded as used.