### PR TITLE
chore: Update code linter commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ Dart Code Linter (DCL) is a powerful toolkit designed to enhance your developmen
 
 ```sh
 $ dart pub add --dev dart_code_linter
-
-# or for a Flutter package
-$ flutter pub add --dev dart_code_linter
 ```
 
 ## Basic configuration
@@ -119,9 +116,6 @@ Reports code metrics, rules and anti-patterns violations. To execute the command
 
 ```sh
 $ dart run dart_code_linter:metrics analyze lib
-
-# or for a Flutter package
-$ flutter pub run dart_code_linter:metrics analyze lib
 ```
 
 It will produce a result in one of the format:
@@ -140,9 +134,6 @@ Checks unnecessary nullable parameters in functions, methods, constructors. To e
 
 ```sh
 $ dart run dart_code_linter:metrics check-unnecessary-nullable lib
-
-# or for a Flutter package
-$ flutter pub run dart_code_linter:metrics check-unnecessary-nullable lib
 ```
 
 It will produce a result in one of the format:
@@ -158,9 +149,6 @@ Checks unused `*.dart` files. To execute the command, run
 
 ```sh
 $ dart run dart_code_linter:metrics check-unused-files lib
-
-# or for a Flutter package
-$ flutter pub run dart_code_linter:metrics check-unused-files lib
 ```
 
 It will produce a result in one of the format:
@@ -192,9 +180,6 @@ To execute the command, run
 
 ```sh
 $ dart run dart_code_linter:metrics check-unused-l10n lib
-
-# or for a Flutter package
-$ flutter pub run dart_code_linter:metrics check-unused-l10n lib
 ```
 
 It will produce a result in one of the format:
@@ -209,9 +194,6 @@ Checks unused code in `*.dart` files. To execute the command, run
 
 ```sh
 $ dart run dart_code_linter:metrics check-unused-code lib
-
-# or for a Flutter package
-$ flutter pub run dart_code_linter:metrics check-unused-code lib
 ```
 
 It will produce a result in one of the format:

--- a/example/lib/src/unnecessary_nullable_widget.dart
+++ b/example/lib/src/unnecessary_nullable_widget.dart
@@ -5,7 +5,7 @@ class UnnecessaryNullableWidget extends StatelessWidget {
 
   /// This callback declares a nullable parameter `value`,
   /// but it's actually always used with non-nullable argument.
-  /// Run `flutter pub run dart_code_linter:metrics check-unnecessary-nullable lib` to see the report.
+  /// Run `dart run dart_code_linter:metrics check-unnecessary-nullable lib` to see the report.
   void someCallback(String? value) {
     print(value);
   }

--- a/example/lib/src/unused_code_widget.dart
+++ b/example/lib/src/unused_code_widget.dart
@@ -3,12 +3,12 @@ import 'package:flutter/src/widgets/framework.dart';
 
 /// This variable is not referenced in any file and is actually unused.
 /// In order to spot such declarations,
-/// run `flutter pub run dart_code_linter:metrics check-unused-code lib`.
+/// run `dart rundart_code_linter:metrics check-unused-code lib`.
 const someVariable = '1';
 
 /// This function is not referenced in any file and is actually unused.
 /// In order to spot such declarations,
-/// run `flutter pub run dart_code_linter:metrics check-unused-code lib`.
+/// run `dart rundart_code_linter:metrics check-unused-code lib`.
 String topLevelFunction() {
   print('Actually unused');
 

--- a/example/lib/src/unused_code_widget.dart
+++ b/example/lib/src/unused_code_widget.dart
@@ -3,12 +3,12 @@ import 'package:flutter/src/widgets/framework.dart';
 
 /// This variable is not referenced in any file and is actually unused.
 /// In order to spot such declarations,
-/// run `dart rundart_code_linter:metrics check-unused-code lib`.
+/// run `dart run dart_code_linter:metrics check-unused-code lib`.
 const someVariable = '1';
 
 /// This function is not referenced in any file and is actually unused.
 /// In order to spot such declarations,
-/// run `dart rundart_code_linter:metrics check-unused-code lib`.
+/// run `dart run dart_code_linter:metrics check-unused-code lib`.
 String topLevelFunction() {
   print('Actually unused');
 

--- a/example/lib/src/unused_widget.dart
+++ b/example/lib/src/unused_widget.dart
@@ -2,7 +2,7 @@ import 'package:flutter/widgets.dart';
 
 /// This widget is not imported by any other file and is not a project entry point.
 /// It will be reported by `check-unused-files` command.
-/// Run `flutter pub run dart_code_linter:metrics check-unused-files lib` to see the report.
+/// Run `dart run dart_code_linter:metrics check-unused-files lib` to see the report.
 class UnusedWidget extends StatelessWidget {
   const UnusedWidget({super.key});
 


### PR DESCRIPTION
The launch command is deprecated in the readme and in the docs page