### PR TITLE
fix: generating report file when find issues in the report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,20 @@
 # Changelog
+## 1.2.1
+- Fixed generating report file when find issues in the report
 ## 1.2.0
-- Add fix command
-- Add prefer single quotes rule
-- Add prefer first or null rule
-- Add no blank line before single return rule
-- Fix rule avoid dynamic to extensions definition
+- Added fix command
+- Added prefer single quotes rule
+- Added prefer first or null rule
+- Added no blank line before single return rule
+- Fixed rule avoid dynamic to extensions definition
 ## 1.1.5
 - Removed deprecated fields in analysis options and collection method
-- Fix changelog URL for update available warning
+- Fixed changelog URL for update available warning
 ## 1.1.4
-- Fix some test
-- Revert `analyzer` ^6.0.0 to ^5.14.0
+- Fixed some test
+- Reverted `analyzer` ^6.0.0 to ^5.14.0
 ## 1.1.3
-- Fix some test
+- Fixed some test
 ## 1.1.2
 - Append new presset `analysis_options.1.0.0.yaml`
 ## 1.1.1

--- a/lib/src/analyzers/lint_analyzer/reporters/reporters_list/json/lint_json_reporter.dart
+++ b/lib/src/analyzers/lint_analyzer/reporters/reporters_list/json/lint_json_reporter.dart
@@ -49,6 +49,7 @@ class LintJsonReporter extends JsonReporter<LintFileReport, LintReportParams> {
     });
 
     output.write(encodedReport);
+    await output.close();
   }
 
   Map<String, Object> _lintFileReportToJson(LintFileReport report) => {

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '1.2.0';
+const packageVersion = '1.2.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_code_linter
-version: 1.2.0
+version: 1.2.1
 description: Dart Code Linter is a software analytics tool that helps developers analyse and improve software quality. Dart Code Linter is based on a fork of Dart Code Metrics.
 repository: https://github.com/bancolombia/dart-code-linter
 

--- a/test/src/analyzers/lint_analyzer/reporters/reporters_list/json/lint_json_reporter_test.dart
+++ b/test/src/analyzers/lint_analyzer/reporters/reporters_list/json/lint_json_reporter_test.dart
@@ -17,6 +17,7 @@ void main() {
 
     setUp(() {
       output = IOSinkMock();
+      when(output.close).thenAnswer((_) async => null);
     });
 
     test('empty report', () {
@@ -119,6 +120,7 @@ void main() {
           'violations': 2,
         }),
       );
+      verify(output.close).called(1);
     });
   });
 }

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -1,12 +1,12 @@
 name: dart_code_linter_plugin_loader
 description: This pubspec determines the version of the analyzer plugin to load.
-version: 1.2.0
+version: 1.2.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  dart_code_linter: 1.2.0
+  dart_code_linter: 1.2.1
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
The problem occurs when the report has issues and  the command don't have the flags `--no-fatal-style,  --no-fatal-warnings, --no-fatal-performance  `