### PR TITLE
Add deprecation message for prefer-commenting-analyzer-ignores in dart_all.yaml

### DIFF
--- a/lib/presets/dart_all.yaml
+++ b/lib/presets/dart_all.yaml
@@ -35,7 +35,7 @@ dart_code_linter:
     - no-magic-number
     - no-object-declaration
     - prefer-async-await
-    - prefer-commenting-analyzer-ignores
+    - prefer-commenting-analyzer-ignores # This rule is deprecated. Since Dart 3.5.0 you can use https://dart.dev/tools/linter-rules/document_ignores instead.
     - prefer-conditional-expressions
     - prefer-correct-identifier-length
     - prefer-correct-test-file-name


### PR DESCRIPTION
Fixes #160 