### PR TITLE
feat: add require trailing commas rule

### DIFF
--- a/lib/src/analyzers/lint_analyzer/rules/rules_factory.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_factory.dart
@@ -77,6 +77,7 @@ import 'rules_list/prefer_static_class/prefer_static_class_rule.dart';
 import 'rules_list/prefer_trailing_comma/prefer_trailing_comma_rule.dart';
 import 'rules_list/prefer_using_list_view/prefer_using_list_view_rule.dart';
 import 'rules_list/provide_correct_intl_args/provide_correct_intl_args_rule.dart';
+import 'rules_list/require_trailing_commas/require_trailing_commas_rule.dart';
 import 'rules_list/tag_name/tag_name_rule.dart';
 import 'rules_list/use_setstate_synchronously/use_setstate_synchronously_rule.dart';
 
@@ -170,11 +171,14 @@ final _implementedRules = <String, Rule Function(Map<String, Object>)>{
   PreferUsingListViewRule.ruleId: PreferUsingListViewRule.new,
   ProvideCorrectIntlArgsRule.ruleId: ProvideCorrectIntlArgsRule.new,
   TagNameRule.ruleId: TagNameRule.new,
+  RequireTrailingCommasRule.ruleId: RequireTrailingCommasRule.new,
 };
 
 Iterable<String> get allRuleIds => _implementedRules.keys;
 
 Iterable<Rule> getRulesById(Map<String, Map<String, Object>> rulesConfig) =>
-    List.unmodifiable(_implementedRules.keys
-        .where((id) => rulesConfig.keys.contains(id))
-        .map<Rule>((id) => _implementedRules[id]!(rulesConfig[id]!)));
+    List.unmodifiable(
+      _implementedRules.keys
+          .where((id) => rulesConfig.keys.contains(id))
+          .map<Rule>((id) => _implementedRules[id]!(rulesConfig[id]!)),
+    );

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/config_parser.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/config_parser.dart
@@ -1,0 +1,12 @@
+part of 'require_trailing_commas_rule.dart';
+
+class _ConfigParser {
+  static const _minParametersConfigName = 'min-parameters';
+
+  static int? parseMinParameters(Map<String, Object> config) {
+    final breakpoint = config[_minParametersConfigName];
+
+    return breakpoint != null ? int.tryParse(breakpoint.toString()) : null;
+  }
+
+}

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/require_trailing_commas_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/require_trailing_commas_rule.dart
@@ -1,0 +1,66 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/source/line_info.dart';
+
+import '../../../../../utils/node_utils.dart';
+import '../../../lint_utils.dart';
+import '../../../models/internal_resolved_unit_result.dart';
+import '../../../models/issue.dart';
+import '../../../models/replacement.dart';
+import '../../../models/severity.dart';
+import '../../models/dart_rule.dart';
+import '../../rule_utils.dart';
+
+part 'config_parser.dart';
+
+part 'visitor.dart';
+
+class RequireTrailingCommasRule extends DartRule {
+  static const String ruleId = 'require-trailing-commas';
+
+  static const _warningMessage = 'Require trailing comma.';
+  static const _correctionMessage = 'Add trailing comma.';
+
+  final int? _minParameters;
+
+  RequireTrailingCommasRule([Map<String, Object> config = const {}])
+      : _minParameters = _ConfigParser.parseMinParameters(config),
+        super(
+          id: ruleId,
+          severity: readSeverity(config, Severity.style),
+          excludes: readExcludes(config),
+          includes: readIncludes(config),
+        );
+
+  @override
+  Map<String, Object?> toJson() {
+    final json = super.toJson();
+    json[_ConfigParser._minParametersConfigName] = _minParameters;
+
+    return json;
+  }
+
+  @override
+  Iterable<Issue> check(InternalResolvedUnitResult source) {
+    final visitor = _Visitor(source.lineInfo, _minParameters ?? 0);
+    source.unit.visitChildren(visitor);
+
+    return visitor.nodes
+        .map(
+          (node) => createIssue(
+            rule: this,
+            location: nodeLocation(node: node, source: source),
+            message: _warningMessage,
+            replacement: Replacement(
+              comment: _correctionMessage,
+              replacement:
+                  '${source.content.substring(node.offset, node.end)},',
+            ),
+          ),
+        )
+        .toList(growable: false);
+  }
+}

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/visitor.dart
@@ -1,0 +1,147 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// Source: https://github.com/dart-lang/sdk/blob/main/pkg/linter/lib/src/rules/require_trailing_commas.dart
+
+part of 'require_trailing_commas_rule.dart';
+
+class _Visitor extends RecursiveAstVisitor<void> {
+  final LineInfo _lineInfo;
+  final int _minParameters;
+
+  final _nodes = <AstNode>[];
+
+  Iterable<AstNode> get nodes => _nodes;
+
+  _Visitor(this._lineInfo, this._minParameters);
+
+  @override
+  void visitArgumentList(ArgumentList node) {
+    super.visitArgumentList(node);
+    if (node.arguments.isEmpty) return;
+    if (node.arguments.length <= _minParameters) return;
+    _checkTrailingComma(
+      openingToken: node.leftParenthesis,
+      closingToken: node.rightParenthesis,
+      lastNode: node.arguments.last,
+    );
+  }
+
+  @override
+  void visitAssertInitializer(AssertInitializer node) {
+    super.visitAssertInitializer(node);
+    _checkTrailingComma(
+      openingToken: node.leftParenthesis,
+      closingToken: node.rightParenthesis,
+      lastNode: node.message ?? node.condition,
+    );
+  }
+
+  @override
+  void visitAssertStatement(AssertStatement node) {
+    super.visitAssertStatement(node);
+    _checkTrailingComma(
+      openingToken: node.leftParenthesis,
+      closingToken: node.rightParenthesis,
+      lastNode: node.message ?? node.condition,
+    );
+  }
+
+  @override
+  void visitFormalParameterList(FormalParameterList node) {
+    super.visitFormalParameterList(node);
+    if (node.parameters.isEmpty) return;
+    _checkTrailingComma(
+      openingToken: node.leftParenthesis,
+      closingToken: node.rightParenthesis,
+      lastNode: node.parameters.last,
+      errorToken: node.rightDelimiter ?? node.rightParenthesis,
+    );
+  }
+
+  @override
+  void visitListLiteral(ListLiteral node) {
+    super.visitListLiteral(node);
+    if (node.elements.isNotEmpty) {
+      _checkTrailingComma(
+        openingToken: node.leftBracket,
+        closingToken: node.rightBracket,
+        lastNode: node.elements.last,
+      );
+    }
+  }
+
+  @override
+  void visitSetOrMapLiteral(SetOrMapLiteral node) {
+    super.visitSetOrMapLiteral(node);
+    if (node.elements.isNotEmpty) {
+      _checkTrailingComma(
+        openingToken: node.leftBracket,
+        closingToken: node.rightBracket,
+        lastNode: node.elements.last,
+      );
+    }
+  }
+
+  void _checkTrailingComma({
+    required Token openingToken,
+    required Token closingToken,
+    required AstNode lastNode,
+    Token? errorToken,
+  }) {
+    errorToken ??= closingToken;
+
+    // Early exit if trailing comma is present.
+    if (lastNode.endToken.next?.type == TokenType.COMMA) return;
+
+    // No trailing comma is needed if the function call or declaration, up to
+    // the closing parenthesis, fits on a single line. Ensuring the left and
+    // right parenthesis are on the same line is sufficient since `dart format`
+    // places the left parenthesis right after the identifier (on the same
+    // line).
+    if (_isSameLine(openingToken, closingToken)) return;
+
+    // Check the last parameter to determine if there are any exceptions.
+    if (_shouldAllowTrailingCommaException(lastNode)) return;
+
+    _nodes.add(lastNode);
+  }
+
+  bool _isSameLine(Token token1, Token token2) =>
+      _lineInfo.getLocation(token1.offset).lineNumber ==
+      _lineInfo.getLocation(token2.end).lineNumber;
+
+  bool _shouldAllowTrailingCommaException(AstNode lastNode) {
+    // No exceptions are allowed if the last argument is named.
+    if (lastNode is FormalParameter && lastNode.isNamed) return false;
+
+    // No exceptions are allowed if the entire last argument fits on one line.
+    if (_isSameLine(lastNode.beginToken, lastNode.endToken)) return false;
+
+    // Exception is allowed if the last argument is a function literal.
+    if (lastNode is FunctionExpression && lastNode.body is BlockFunctionBody) {
+      return true;
+    }
+
+    // Exception is allowed if the last argument is a (multiline) string
+    // literal.
+    if (lastNode is StringLiteral) return true;
+
+    // Exception is allowed if the last argument is a anonymous function call.
+    // This case arises a lot in asserts.
+    if (lastNode is FunctionExpressionInvocation &&
+        lastNode.function is FunctionExpression &&
+        _isSameLine(
+          lastNode.argumentList.leftParenthesis,
+          lastNode.argumentList.rightParenthesis,
+        )) {
+      return true;
+    }
+
+    // Exception is allowed if the last argument is a set, map or list literal.
+    if (lastNode is SetOrMapLiteral || lastNode is ListLiteral) return true;
+
+    return false;
+  }
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/examples/correct_example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/examples/correct_example.dart
@@ -1,0 +1,127 @@
+void firstFunction(
+  String firstArgument,
+  String secondArgument,
+  String thirdArgument,
+) {
+  return;
+}
+
+void secondFunction(String arg1) {
+  firstFunction(
+    '',
+    '',
+    '',
+  );
+}
+
+void thirdFunction(String arg1, void Function() callback) {}
+
+void forthFunction(void Function() callback) {}
+
+class TestClass {
+  void firstMethod(
+    String firstArgument,
+    String secondArgument,
+    String thirdArgument,
+  ) {
+    return;
+  }
+
+  void secondMethod() {
+    firstMethod(
+      'some string',
+      'some other string',
+      'and another string for length exceed',
+    );
+
+    thirdFunction('', () {
+      return;
+    });
+
+    forthFunction(() {
+      return;
+    });
+  }
+
+  void thirdMethod(
+    String arg1,
+  ) {
+    firstMethod(
+      arg1,
+      '',
+      '',
+    );
+    firstFunction(
+      arg1,
+      '',
+      '',
+    );
+  }
+}
+
+enum FirstEnum {
+  firstItem,
+  secondItem,
+  thirdItem,
+  forthItem,
+  fifthItem,
+  sixthItem,
+}
+
+enum SecondEnum {
+  firstItem,
+}
+
+enum ThirdEnum { firstItem }
+
+class FirstClass {
+  final num firstField;
+  final num secondField;
+  final num thirdField;
+  final num forthField;
+
+  const FirstClass(
+    this.firstField,
+    this.secondField,
+    this.thirdField,
+    this.forthField,
+  );
+}
+
+const firstInstance = FirstClass(0, 0, 0, 0);
+const secondInstance = FirstClass(
+  0,
+  0,
+  0,
+  0,
+);
+
+final firstArray = ['some string'];
+final secondArray = [
+  'some string',
+  'some other string',
+  'and another string for length exceed',
+];
+final thirdArray = [
+  'some string',
+];
+
+final firstSet = {'some string'};
+final secondSet = {
+  'some string',
+  'some other string',
+  'and another string for length exceed',
+};
+final thirdSet = {
+  'some string',
+};
+
+final firstMap = {'some string': 'some string'};
+final secondMap = {
+  'some string': 'and another string for length exceed',
+  'and another string for length exceed':
+      'and another string for length exceed',
+};
+final thirdMap = {
+  'some string': 'some string',
+};

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/examples/incorrect_example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/examples/incorrect_example.dart
@@ -1,0 +1,99 @@
+// LINT
+void firstFunction(
+    String firstArgument, String secondArgument, String thirdArgument) {
+  return;
+}
+
+void secondFunction() {
+  firstFunction('some string', 'some other string',
+      'and another string for length exceed'); // LINT
+}
+
+void thirdFunction(String someLongVarName, void Function() someLongCallbackName,
+    String arg3) {} // LINT
+
+class TestClass {
+  // LINT
+  void firstMethod(
+      String firstArgument, String secondArgument, String thirdArgument) {
+    return;
+  }
+
+  void secondMethod() {
+    firstMethod('some string', 'some other string',
+        'and another string for length exceed'); // LINT
+
+    thirdFunction('some string', () {
+      return;
+    }, 'some other string'); // LINT
+  }
+}
+
+enum FirstEnum {
+  firstItem,
+  secondItem,
+  thirdItem,
+  forthItem,
+  fifthItem,
+  sixthItem
+}
+
+class FirstClass {
+  final num firstField;
+  final num secondField;
+  final num thirdField;
+  final num forthField;
+
+  // LINT
+  const FirstClass(
+      this.firstField, this.secondField, this.thirdField, this.forthField);
+}
+
+const instance =
+    FirstClass(3.14159265359, 3.14159265359, 3.14159265359, 3.14159265359);
+
+final secondArray = [
+  'some string',
+  'some other string',
+  'and another string for length exceed' // LINT
+];
+
+final secondSet = {
+  'some string',
+  'some other string',
+  'and another string for length exceed' // LINT
+};
+
+final secondMap = {
+  'some string': 'and another string for length exceed',
+  // LINT
+  'and another string for length exceed': 'and another string for length exceed'
+};
+
+typedef SecondFunctionType = void Function(String firstArgument,
+    String secondArgument, String thirdArgument, String forthArgument);
+
+class SecondClass {
+  final SecondFunctionType secondFunction;
+
+  const SecondClass({required this.secondFunction});
+}
+
+final secondInstance = SecondClass(
+  secondFunction: (String firstArgument, String secondArgument,
+      String thirdArgument, String forthArgument) {
+    // LINT
+    return;
+  },
+);
+
+String printObject(Object object) {
+  return 'Object: $object';
+}
+
+final x = printObject(FirstClass(
+  3.14159265359,
+  3.14159265359,
+  3.14159265359,
+  3.14159265359,
+)); // LINT

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/require_trailing_commas_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/require_trailing_commas_rule_test.dart
@@ -1,0 +1,184 @@
+import 'package:dart_code_linter/src/analyzers/lint_analyzer/models/severity.dart';
+import 'package:dart_code_linter/src/analyzers/lint_analyzer/rules/rules_list/require_trailing_commas/require_trailing_commas_rule.dart';
+import 'package:test/test.dart';
+
+import '../../../../../helpers/rule_test_helper.dart';
+
+// ignore_for_file: avoid_escaping_inner_quotes
+
+const _correctExamplePath =
+    'require_trailing_commas/examples/correct_example.dart';
+const _incorrectExamplePath =
+    'require_trailing_commas/examples/incorrect_example.dart';
+
+void main() {
+  group('RequireTrailingCommas', () {
+    test('initialization', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_correctExamplePath);
+      final issues = RequireTrailingCommasRule().check(unit);
+
+      RuleTestHelper.verifyInitialization(
+        issues: issues,
+        ruleId: 'prefer-trailing-comma',
+        severity: Severity.style,
+      );
+    });
+
+    test('with default config reports about found issues', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_incorrectExamplePath);
+      final issues = RequireTrailingCommasRule().check(unit);
+
+      RuleTestHelper.verifyIssues(
+        issues: issues,
+        startLines: [3, 9, 13, 18, 24, 28, 49, 58, 64, 70, 74, 84, 94],
+        startColumns: [50, 7, 5, 52, 9, 8, 59, 3, 3, 3, 50, 29, 23],
+        locationTexts: [
+          'String thirdArgument',
+          "'and another string for length exceed'",
+          'String arg3',
+          'String thirdArgument',
+          "'and another string for length exceed'",
+          "'some other string'",
+          'this.forthField',
+          "'and another string for length exceed'",
+          "'and another string for length exceed'",
+          "'and another string for length exceed': 'and another string for length exceed'",
+          "String forthArgument",
+          "String forthArgument",
+          'FirstClass(\n'
+              '  3.14159265359,\n'
+              '  3.14159265359,\n'
+              '  3.14159265359,\n'
+              '  3.14159265359,\n'
+              ')',
+        ],
+        messages: [
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+        ],
+        replacementComments: [
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+        ],
+        replacements: [
+          'String thirdArgument,',
+          "'and another string for length exceed',",
+          'String arg3,',
+          'String thirdArgument,',
+          "'and another string for length exceed',",
+          "'some other string',",
+          'this.forthField,',
+          "'and another string for length exceed',",
+          "'and another string for length exceed',",
+          "'and another string for length exceed': 'and another string for length exceed',",
+          "String forthArgument,",
+          "String forthArgument,",
+          'FirstClass(\n'
+              '  3.14159265359,\n'
+              '  3.14159265359,\n'
+              '  3.14159265359,\n'
+              '  3.14159265359,\n'
+              '),',
+        ],
+      );
+    });
+
+    test('with default config reports no issues', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_correctExamplePath);
+      final issues = RequireTrailingCommasRule().check(unit);
+
+      RuleTestHelper.verifyNoIssues(issues);
+    });
+
+    test('with custom config reports about found issues', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_incorrectExamplePath);
+      final config = {'min-parameters': 1};
+
+      final issues = RequireTrailingCommasRule(config).check(unit);
+
+      RuleTestHelper.verifyIssues(
+        issues: issues,
+        startLines: [3, 9, 13, 18, 24, 28, 49, 58, 64, 70, 74, 84],
+        startColumns: [50, 7, 5, 52, 9, 8, 59, 3, 3, 3, 50, 29],
+        locationTexts: [
+          'String thirdArgument',
+          "'and another string for length exceed'",
+          'String arg3',
+          'String thirdArgument',
+          "'and another string for length exceed'",
+          "'some other string'",
+          'this.forthField',
+          "'and another string for length exceed'",
+          "'and another string for length exceed'",
+          "'and another string for length exceed': 'and another string for length exceed'",
+          "String forthArgument",
+          "String forthArgument",
+        ],
+        messages: [
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+          'Require trailing comma.',
+        ],
+        replacementComments: [
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+          'Add trailing comma.',
+        ],
+        replacements: [
+          'String thirdArgument,',
+          "'and another string for length exceed',",
+          'String arg3,',
+          'String thirdArgument,',
+          "'and another string for length exceed',",
+          "'some other string',",
+          'this.forthField,',
+          "'and another string for length exceed',",
+          "'and another string for length exceed',",
+          "'and another string for length exceed': 'and another string for length exceed',",
+          "String forthArgument,",
+          "String forthArgument,",
+        ],
+      );
+    });
+  });
+}


### PR DESCRIPTION
Cloned the behavior of require_trailing_commas from the standard SDK. Also added support for the min-parameters configuration, which allows the rule to be customized based on the minimum number of parameters required to enforce trailing commas.