### PR TITLE
Fix installation command formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dart Code Linter (DCL) is a powerful toolkit designed to enhance your developmen
 ## Installation
 
 ```sh
-$ dart pub add --dev dart_code_linter
+dart pub add --dev dart_code_linter
 ```
 
 ## Basic configuration


### PR DESCRIPTION
When you click the copy icon on github or pub.dev the `$` is included and makes its it so you can't directly paste it.