### PR TITLE
feat: add rule prefer-named-record-fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 3.1.0-beta.1
+- Add rule `prefer-named-record-fields`.
+
 ## 3.0.0-beta.1
 - [Breaking] Update dart sdk constraints to `>=3.4.0 <4.0.0`.
 - Update `analyzer` to version ^7.4.4

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -81,6 +81,7 @@ dart_code_linter:
     - prefer-moving-to-variable:
         exclude:
           - test/**
+    - prefer-named-record-fields
     - prefer-trailing-comma
 
 linter:

--- a/lib/presets/dart_all.yaml
+++ b/lib/presets/dart_all.yaml
@@ -47,6 +47,7 @@ dart_code_linter:
     - prefer-last
     - prefer-match-file-name
     - prefer-moving-to-variable
+    - prefer-named-record-fields
     - prefer-static-class
     - prefer-trailing-comma
     - tag-name
@@ -96,6 +97,7 @@ dart_code_linter:
     - avoid-long-records
     - match-positional-field-names-on-assignment
     - avoid-redundant-positional-field-name
+    - prefer-named-record-fields
     - avoid-nested-switch-expressions
     - avoid-bottom-type-in-patterns
     - avoid-explicit-pattern-field-name

--- a/lib/src/analyzers/lint_analyzer/rules/rules_factory.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_factory.dart
@@ -70,6 +70,7 @@ import 'rules_list/prefer_iterable_of/prefer_iterable_of_rule.dart';
 import 'rules_list/prefer_last/prefer_last_rule.dart';
 import 'rules_list/prefer_match_file_name/prefer_match_file_name_rule.dart';
 import 'rules_list/prefer_moving_to_variable/prefer_moving_to_variable_rule.dart';
+import 'rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart';
 import 'rules_list/prefer_provide_intl_description/prefer_provide_intl_description_rule.dart';
 import 'rules_list/prefer_single_quotes/prefer_single_qoutes.dart';
 import 'rules_list/prefer_single_widget_per_file/prefer_single_widget_per_file_rule.dart';
@@ -163,6 +164,7 @@ final _implementedRules = <String, Rule Function(Map<String, Object>)>{
   PreferLastRule.ruleId: PreferLastRule.new,
   PreferMatchFileNameRule.ruleId: PreferMatchFileNameRule.new,
   PreferMovingToVariableRule.ruleId: PreferMovingToVariableRule.new,
+  PreferNamedRecordFieldsRule.ruleId: PreferNamedRecordFieldsRule.new,
   PreferProvideIntlDescriptionRule.ruleId: PreferProvideIntlDescriptionRule.new,
   PreferSingleWidgetPerFileRule.ruleId: PreferSingleWidgetPerFileRule.new,
   PreferStaticClassRule.ruleId: PreferStaticClassRule.new,

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart
@@ -1,0 +1,180 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../../../../../utils/node_utils.dart';
+import '../../../lint_utils.dart';
+import '../../../models/internal_resolved_unit_result.dart';
+import '../../../models/issue.dart';
+import '../../../models/replacement.dart';
+import '../../../models/severity.dart';
+import '../../models/dart_rule.dart';
+import '../../rule_utils.dart';
+
+part 'visitor.dart';
+
+class PreferNamedRecordFieldsRule extends DartRule {
+  static const ruleId = 'prefer-named-record-fields';
+  static const warningMessage =
+      'Prefer named record fields over positional fields for better code readability.';
+  static const replaceComment = 'Consider using named record fields.';
+
+  PreferNamedRecordFieldsRule([Map<String, Object> config = const {}])
+      : super(
+          id: ruleId,
+          severity: readSeverity(config, Severity.style),
+          excludes: readExcludes(config),
+          includes: readIncludes(config),
+        );
+
+  @override
+  Iterable<Issue> check(InternalResolvedUnitResult source) {
+    final visitor = _Visitor();
+    source.unit.visitChildren(visitor);
+
+    return [
+      ...visitor.recordTypeAnnotations.map((recordType) => createIssue(
+            rule: this,
+            location: nodeLocation(node: recordType, source: source),
+            message: warningMessage,
+            replacement: _createReplacementForRecordType(recordType),
+          )),
+      ...visitor.recordLiterals.map((recordLiteral) => createIssue(
+            rule: this,
+            location: nodeLocation(node: recordLiteral, source: source),
+            message: warningMessage,
+            replacement: _createReplacementForRecordLiteral(recordLiteral),
+          )),
+    ].toList(growable: false);
+  }
+
+  Replacement _createReplacementForRecordType(RecordTypeAnnotation recordType) {
+    final positionalFields = recordType.positionalFields;
+
+    if (positionalFields.isEmpty) {
+      return const Replacement(
+        comment: replaceComment,
+        replacement: '',
+      );
+    }
+
+    final namedFields = <String>[];
+    for (var i = 0; i < positionalFields.length; i++) {
+      final field = positionalFields[i];
+      final fieldName = _generateFieldName(field.type, i);
+      namedFields.add('${field.type} $fieldName');
+    }
+
+    final namedFieldsStr = namedFields.join(', ');
+    final existingNamed = recordType.namedFields;
+
+    String replacement;
+    replacement = existingNamed != null && existingNamed.fields.isNotEmpty
+        ? '({$namedFieldsStr, ${existingNamed.toSource()}})'
+        : '({$namedFieldsStr})';
+
+    return Replacement(
+      comment: replaceComment,
+      replacement: replacement,
+    );
+  }
+
+  Replacement _createReplacementForRecordLiteral(RecordLiteral recordLiteral) {
+    final positionalFields = recordLiteral.fields
+        .where((field) => field is! NamedExpression)
+        .toList();
+
+    if (positionalFields.isEmpty) {
+      return const Replacement(
+        comment: replaceComment,
+        replacement: '',
+      );
+    }
+
+    final namedFields = <String>[];
+    for (var i = 0; i < positionalFields.length; i++) {
+      final field = positionalFields[i];
+      final fieldName = _generateFieldNameFromExpression(field, i);
+      namedFields.add('$fieldName: ${field.toSource()}');
+    }
+
+    final namedFieldsStr = namedFields.join(', ');
+    final existingNamed = recordLiteral.fields
+        .whereType<NamedExpression>()
+        .map((field) => field.toSource())
+        .join(', ');
+
+    String replacement;
+    replacement = existingNamed.isNotEmpty
+        ? '($namedFieldsStr, $existingNamed)'
+        : '($namedFieldsStr)';
+
+    return Replacement(
+      comment: replaceComment,
+      replacement: replacement,
+    );
+  }
+
+  String _generateFieldName(TypeAnnotation? type, int index) {
+    if (type != null) {
+      final typeName = type.toSource().toLowerCase();
+
+      switch (typeName) {
+        case 'string':
+          return 'text';
+        case 'int':
+        case 'integer':
+          return 'number';
+        case 'double':
+        case 'num':
+          return 'value';
+        case 'bool':
+        case 'boolean':
+          return 'flag';
+        case 'list':
+          return 'items';
+        case 'map':
+          return 'data';
+        default:
+          if (typeName.startsWith('list<')) {
+            return 'items';
+          } else if (typeName.startsWith('map<')) {
+            return 'data';
+          } else if (typeName.length > 3) {
+            return typeName.substring(0, 1).toLowerCase() +
+                typeName.substring(1);
+          }
+      }
+    }
+
+    // Fallback a nombres genéricos
+    return 'field${index + 1}';
+  }
+
+  String _generateFieldNameFromExpression(AstNode expression, int index) {
+    // Intentar inferir un nombre del contexto de la expresión
+    if (expression is StringLiteral) {
+      return 'text';
+    } else if (expression is IntegerLiteral) {
+      return 'number';
+    } else if (expression is DoubleLiteral) {
+      return 'value';
+    } else if (expression is BooleanLiteral) {
+      return 'flag';
+    } else if (expression is ListLiteral) {
+      return 'items';
+    } else if (expression is SetOrMapLiteral) {
+      return 'data';
+    } else if (expression is Identifier) {
+      // Usar el nombre de la variable si es disponible
+      final name = expression.name;
+      if (name.length > 1) {
+        return name;
+      }
+    }
+
+    // Fallback a nombres genéricos
+    return 'field${index + 1}';
+  }
+}

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart
@@ -148,12 +148,10 @@ class PreferNamedRecordFieldsRule extends DartRule {
       }
     }
 
-    // Fallback a nombres genéricos
     return 'field${index + 1}';
   }
 
   String _generateFieldNameFromExpression(AstNode expression, int index) {
-    // Intentar inferir un nombre del contexto de la expresión
     if (expression is StringLiteral) {
       return 'text';
     } else if (expression is IntegerLiteral) {
@@ -167,14 +165,12 @@ class PreferNamedRecordFieldsRule extends DartRule {
     } else if (expression is SetOrMapLiteral) {
       return 'data';
     } else if (expression is Identifier) {
-      // Usar el nombre de la variable si es disponible
       final name = expression.name;
       if (name.length > 1) {
         return name;
       }
     }
 
-    // Fallback a nombres genéricos
     return 'field${index + 1}';
   }
 }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/visitor.dart
@@ -1,0 +1,52 @@
+part of 'prefer_named_record_fields_rule.dart';
+
+class _Visitor extends RecursiveAstVisitor<void> {
+  final _recordTypeAnnotations = <RecordTypeAnnotation>[];
+  final _recordLiterals = <RecordLiteral>[];
+
+  Iterable<RecordTypeAnnotation> get recordTypeAnnotations =>
+      _recordTypeAnnotations;
+  Iterable<RecordLiteral> get recordLiterals => _recordLiterals;
+
+  @override
+  void visitRecordTypeAnnotation(RecordTypeAnnotation node) {
+    super.visitRecordTypeAnnotation(node);
+
+    if (_shouldReportRecordType(node)) {
+      _recordTypeAnnotations.add(node);
+    }
+  }
+
+  @override
+  void visitRecordLiteral(RecordLiteral node) {
+    super.visitRecordLiteral(node);
+
+    if (_shouldReportRecordLiteral(node)) {
+      _recordLiterals.add(node);
+    }
+  }
+
+  bool _shouldReportRecordType(RecordTypeAnnotation recordType) {
+    final positionalCount = recordType.positionalFields.length;
+    final namedCount = recordType.namedFields?.fields.length ?? 0;
+
+    return (positionalCount > 1 && namedCount == 0) ||
+        (positionalCount >= 2 && positionalCount > namedCount);
+  }
+
+  bool _shouldReportRecordLiteral(RecordLiteral recordLiteral) {
+    var positionalCount = 0;
+    var namedCount = 0;
+
+    for (final field in recordLiteral.fields) {
+      if (field is NamedExpression) {
+        namedCount++;
+      } else {
+        positionalCount++;
+      }
+    }
+
+    return (positionalCount > 1 && namedCount == 0) ||
+        (positionalCount >= 2 && positionalCount > namedCount);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_code_linter
-version: 3.0.0
+version: 3.1.0-beta.1
 description: Dart Code Linter is a software analytics tool that helps developers analyse and improve software quality. Dart Code Linter is based on a fork of Dart Code Metrics.
 repository: https://github.com/bancolombia/dart-code-linter
 

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/examples/example.dart
@@ -1,0 +1,20 @@
+// Example with problematic record usage
+(String, int) badRecord1;
+void function1() {}
+// Multiple positional fields
+(String, int, bool) badRecord2;
+void function2() {}
+// More than 3 positional fields
+(int, String, double, bool) badRecord3;
+void function3() {}
+// Record literal with only positional fields
+var badLiteral = ('Hello', 42);
+void function4() {}
+
+// Some other code to separate issues
+class SomeClass {
+  void method() {
+    // Another problematic record literal
+    var anotherBad = (1, 'test', true);
+  }
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule_test.dart
@@ -1,0 +1,26 @@
+import 'package:dart_code_linter/src/analyzers/lint_analyzer/models/severity.dart';
+import 'package:dart_code_linter/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart';
+import 'package:test/test.dart';
+
+import '../../../../../helpers/rule_test_helper.dart';
+
+const _examplePath = 'prefer_named_record_fields/examples/example.dart';
+
+void main() {
+  group('PreferNamedRecordFieldsRule', () {
+    test('initialization', () {
+      final rule = PreferNamedRecordFieldsRule();
+
+      expect(rule.id, 'prefer-named-record-fields');
+      expect(rule.severity, Severity.style);
+    });
+
+    test('reports about record types with only positional fields', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_examplePath);
+      final issues = PreferNamedRecordFieldsRule().check(unit);
+
+      expect(issues, isNotEmpty);
+      expect(issues.first.message, contains('Prefer named record fields'));
+    });
+  });
+}


### PR DESCRIPTION
### New Rule Addition

* Added the `prefer-named-record-fields` lint rule implementation in `lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart` and its AST visitor in `visitor.dart`. This rule detects record types and literals with multiple positional fields and suggests converting them to named fields. [[1]](diffhunk://#diff-b6d2f2742166547e24f61fc01704e12c3b622a121e18a35f0810d57351a8100aR1-R180) [[2]](diffhunk://#diff-4343d101aaf25079a2e20ca5ced7db266bbfe4a0ab559eea6561ee541bb89061R1-R52)
* Registered the new rule in the rule factory (`rules_factory.dart`) and made it available for configuration. [[1]](diffhunk://#diff-43a2b17e36884c352e7c7cdddf39fd14226945324dda115127eaeb090bfc813dR73) [[2]](diffhunk://#diff-43a2b17e36884c352e7c7cdddf39fd14226945324dda115127eaeb090bfc813dR167)

### Configuration and Presets

* Enabled `prefer-named-record-fields` in `analysis_options.yaml` and added it to the `dart_all.yaml` preset, ensuring it is available in standard and comprehensive rule sets. [[1]](diffhunk://#diff-9a967a7bb0393381dfdf9cce102a9cea39146829ab8b38e983d54ac8827486bcR84) [[2]](diffhunk://#diff-a9803e635d670d046ae51eb0319a87cc842770a83e8086722d5d65efdcc7ca2cR50) [[3]](diffhunk://#diff-a9803e635d670d046ae51eb0319a87cc842770a83e8086722d5d65efdcc7ca2cR100)

### Documentation and Versioning

* Updated `CHANGELOG.md` and bumped `pubspec.yaml` version to `3.1.0-beta.1` to document and release the new rule. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR2-R4) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L2-R2)

### Testing

* Added example code and corresponding tests for the new rule to verify its detection of problematic record usage. [[1]](diffhunk://#diff-add9fb1798e37cab5729ec93694ad79c17a4f4d108e0f07c39beca70e34a8bafR1-R20) [[2]](diffhunk://#diff-b28fd2946fc82b63c12f046a4a2f0dee9eb44b33b4730839f019ab3fd763ea78R1-R26)