### PR TITLE
fix: update DCL version in analyzer_plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 3.1.0-beta.2
+- Fixed DCL version in analyzer_plugin.
+
 ## 3.1.0-beta.1
 - Add rule `prefer-named-record-fields`.
 

--- a/lib/presets/analysis_options.1.0.0.yaml
+++ b/lib/presets/analysis_options.1.0.0.yaml
@@ -32,6 +32,7 @@ dart_code_linter:
     - prefer-conditional-expressions
     - prefer-immediate-return
     - prefer-moving-to-variable
+    - prefer-named-record-fields
     - format-comment:
         only-doc-comments: true
     - member-ordering:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_code_linter
-version: 3.1.0-beta.1
+version: 3.1.0-beta.2
 description: Dart Code Linter is a software analytics tool that helps developers analyse and improve software quality. Dart Code Linter is based on a fork of Dart Code Metrics.
 repository: https://github.com/bancolombia/dart-code-linter
 

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -1,12 +1,12 @@
-name: dart_code_linter_plugin_loader
+name: dart_code_linter_analyzer_plugin_loader
 description: This pubspec determines the version of the analyzer plugin to load.
-version: 2.0.0
+version: 3.1.0-beta.2
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  dart_code_linter: 2.0.0
+  dart_code_linter: 3.1.0-beta.2
 
 dev_dependencies:
   lints: ^1.0.1

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -7,6 +7,3 @@ environment:
 
 dependencies:
   dart_code_linter: 3.1.0-beta.2
-
-dev_dependencies:
-  lints: ^1.0.1


### PR DESCRIPTION
Versioning and compatibility updates:
* Updated the main package version to `3.1.0-beta.2` in `pubspec.yaml` and documented the change in `CHANGELOG.md`. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L2-R2) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR2-R4)
* Fixed the analyzer plugin loader package name and version, and updated its SDK requirement and dependency to match the new release in `tools/analyzer_plugin/pubspec.yaml`.

Lint rule enhancements:
* Added the new `prefer-named-record-fields` lint rule to the preset configuration in `lib/presets/analysis_options.1.0.0.yaml`.