### PR TITLE
feat: add new rule prefer-media-query-direct-access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 3.1.0-beta.3
+- Add rule `prefer-media-query-direct-access`.
+
 ## 3.1.0-beta.2
 - Fixed DCL version in analyzer_plugin.
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -82,6 +82,7 @@ dart_code_linter:
         exclude:
           - test/**
     - prefer-named-record-fields
+    - prefer-media-query-direct-access
     - prefer-trailing-comma
 
 linter:

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -59,6 +59,7 @@ dart_code_linter:
     - prefer-single-quotes
     - no-equal-then-else
     - prefer-async-await
+    - prefer-media-query-direct-access
     - prefer-correct-type-name:
         max-length: 44
     - prefer-match-file-name:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,7 +42,10 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   @override
-  Widget build(BuildContext context) => Scaffold(
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+
+    return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
       ),
@@ -54,7 +57,7 @@ class _MyHomePageState extends State<MyHomePage> {
               'You have pushed the button this many times:',
             ),
             Text(
-              '$_counter',
+              '$_counter +' + size.width.toString(),
               style: Theme.of(context).textTheme.headlineMedium,
             ),
             UnusedCodeWidget(),
@@ -71,5 +74,7 @@ class _MyHomePageState extends State<MyHomePage> {
         onPressed: () => _incrementCounter(context),
         tooltip: 'Increment',
         child: const Icon(Icons.add),
-      ));
+      ),
+    );
+  }
 }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_factory.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_factory.dart
@@ -69,6 +69,7 @@ import 'rules_list/prefer_intl_name/prefer_intl_name_rule.dart';
 import 'rules_list/prefer_iterable_of/prefer_iterable_of_rule.dart';
 import 'rules_list/prefer_last/prefer_last_rule.dart';
 import 'rules_list/prefer_match_file_name/prefer_match_file_name_rule.dart';
+import 'rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule.dart';
 import 'rules_list/prefer_moving_to_variable/prefer_moving_to_variable_rule.dart';
 import 'rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart';
 import 'rules_list/prefer_provide_intl_description/prefer_provide_intl_description_rule.dart';
@@ -163,6 +164,7 @@ final _implementedRules = <String, Rule Function(Map<String, Object>)>{
   PreferIterableOfRule.ruleId: PreferIterableOfRule.new,
   PreferLastRule.ruleId: PreferLastRule.new,
   PreferMatchFileNameRule.ruleId: PreferMatchFileNameRule.new,
+  PreferMediaQueryDirectAccessRule.ruleId: PreferMediaQueryDirectAccessRule.new,
   PreferMovingToVariableRule.ruleId: PreferMovingToVariableRule.new,
   PreferNamedRecordFieldsRule.ruleId: PreferNamedRecordFieldsRule.new,
   PreferProvideIntlDescriptionRule.ruleId: PreferProvideIntlDescriptionRule.new,

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule.dart
@@ -1,0 +1,50 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../../../../../../lint_analyzer.dart';
+import '../../../../../utils/node_utils.dart';
+import '../../../lint_utils.dart';
+import '../../../models/internal_resolved_unit_result.dart';
+import '../../models/dart_rule.dart';
+import '../../rule_utils.dart';
+
+part 'visitor.dart';
+
+class PreferMediaQueryDirectAccessRule extends DartRule {
+  static const ruleId = 'prefer-media-query-direct-access';
+  static const warningMessage =
+      'Prefer direct access to MediaQuery properties for better code readability.';
+  static const replaceComment =
+      'Consider accessing MediaQuery properties directly.';
+
+  PreferMediaQueryDirectAccessRule([Map<String, Object> config = const {}])
+      : super(
+          id: ruleId,
+          severity: readSeverity(config, Severity.style),
+          excludes: readExcludes(config),
+          includes: readIncludes(config),
+        );
+
+  @override
+  Iterable<Issue> check(InternalResolvedUnitResult source) {
+    final visitor = _Visitor();
+    source.unit.visitChildren(visitor);
+
+    return visitor.mediaQueryUsages.map((node) => createIssue(
+          rule: this,
+          location: nodeLocation(node: node, source: source),
+          message: warningMessage,
+          replacement: _createReplacement(node),
+        ));
+  }
+
+  Replacement _createReplacement(MethodInvocation node) {
+    final propertyName = node.methodName.name;
+    final replacement = '.${propertyName}Of';
+
+    return Replacement(
+      comment: replaceComment,
+      replacement: replacement,
+    );
+  }
+}

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/visitor.dart
@@ -1,0 +1,37 @@
+part of 'prefer_media_query_direct_access_rule.dart';
+
+class _Visitor extends RecursiveAstVisitor<void> {
+  final _mediaQueryUsages = <MethodInvocation>[];
+
+  Iterable<MethodInvocation> get mediaQueryUsages => _mediaQueryUsages;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    super.visitMethodInvocation(node);
+
+    if (_isMediaQueryUsage(node)) {
+      _mediaQueryUsages.add(node);
+    }
+  }
+
+  bool _isMediaQueryUsage(MethodInvocation node) {
+    final target = node.target;
+    final methodName = node.methodName.name;
+
+    return target is SimpleIdentifier &&
+        target.name == 'MediaQuery' &&
+        (methodName == 'of' ||
+            methodName == 'size' ||
+            methodName == 'padding' ||
+            methodName == 'viewInsets' ||
+            methodName == 'viewPadding' ||
+            methodName == 'orientation' ||
+            methodName == 'devicePixelRatio' ||
+            methodName == 'textScaleFactor' ||
+            methodName == 'platformBrightness' ||
+            methodName == 'accessibleNavigation' ||
+            methodName == 'invertColors' ||
+            methodName == 'highContrast' ||
+            methodName == 'disableAnimations');
+  }
+}

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart
@@ -118,7 +118,7 @@ class PreferNamedRecordFieldsRule extends DartRule {
 
   String _generateFieldName(TypeAnnotation? type, int index) {
     if (type != null) {
-      final typeName = type.toSource().toLowerCase();
+      var typeName = type.toSource().toLowerCase();
 
       switch (typeName) {
         case 'string':
@@ -142,6 +142,10 @@ class PreferNamedRecordFieldsRule extends DartRule {
           } else if (typeName.startsWith('map<')) {
             return 'data';
           } else if (typeName.length > 3) {
+            if (typeName.endsWith('?')) {
+              typeName = typeName.substring(0, typeName.length - 1);
+            }
+
             return typeName.substring(0, 1).toLowerCase() +
                 typeName.substring(1);
           }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '2.0.0';
+const packageVersion = '3.1.0-beta.3';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: dart_code_linter
-version: 3.1.0-beta.2
+version: 3.1.0-beta.3
 description: Dart Code Linter is a software analytics tool that helps developers analyse and improve software quality. Dart Code Linter is based on a fork of Dart Code Metrics.
 repository: https://github.com/bancolombia/dart-code-linter
+issue_tracker: https://github.com/bancolombia/dart-code-linter/issues
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/examples/example.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+class MediaQueryExamples extends StatelessWidget {
+  const MediaQueryExamples({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // ❌ Bad: Using MediaQuery.of(context).property
+    final size = MediaQuery.of(context).size; // LINT
+    final padding = MediaQuery.of(context).padding; // LINT
+    final orientation = MediaQuery.of(context).orientation; // LINT
+    final devicePixelRatio = MediaQuery.of(context).devicePixelRatio; // LINT
+    final textScaleFactor = MediaQuery.of(context).textScaleFactor; // LINT
+    final platformBrightness =
+        MediaQuery.of(context).platformBrightness; // LINT
+    final viewInsets = MediaQuery.of(context).viewInsets; // LINT
+    final viewPadding = MediaQuery.of(context).viewPadding; // LINT
+    final systemGestureInsets =
+        MediaQuery.of(context).systemGestureInsets; // LINT
+    final accessibleNavigation =
+        MediaQuery.of(context).accessibleNavigation; // LINT
+    final highContrast = MediaQuery.of(context).highContrast; // LINT
+    final disableAnimations = MediaQuery.of(context).disableAnimations; // LINT
+    final invertColors = MediaQuery.of(context).invertColors; // LINT
+    final boldText = MediaQuery.of(context).boldText; // LINT
+
+    // ❌ Bad: Nested property access
+    final width = MediaQuery.of(context).size.width; // LINT
+    final height = MediaQuery.of(context).size.height; // LINT
+    final topPadding = MediaQuery.of(context).padding.top; // LINT
+
+    // ✅ Good: Using direct access methods (should not trigger lint)
+    final goodSize = MediaQuery.sizeOf(context);
+    final goodPadding = MediaQuery.paddingOf(context);
+    final goodOrientation = MediaQuery.orientationOf(context);
+    final goodDevicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+    final goodTextScaleFactor = MediaQuery.textScaleFactorOf(context);
+    final goodPlatformBrightness = MediaQuery.platformBrightnessOf(context);
+    final goodViewInsets = MediaQuery.viewInsetsOf(context);
+    final goodViewPadding = MediaQuery.viewPaddingOf(context);
+    final goodSystemGestureInsets = MediaQuery.systemGestureInsetsOf(context);
+    final goodAccessibleNavigation = MediaQuery.accessibleNavigationOf(context);
+    final goodHighContrast = MediaQuery.highContrastOf(context);
+    final goodDisableAnimations = MediaQuery.disableAnimationsOf(context);
+    final goodInvertColors = MediaQuery.invertColorsOf(context);
+    final goodBoldText = MediaQuery.boldTextOf(context);
+
+    // ✅ Good: Direct property access from already obtained MediaQuery
+    final mediaQuery = MediaQuery.of(context);
+    final indirectSize = mediaQuery.size; // Should not trigger lint
+    final indirectPadding = mediaQuery.padding; // Should not trigger lint
+
+    // ❌ Bad: Chained calls
+    final chainedWidth = MediaQuery.of(context).size.width; // LINT
+    final chainedHeight = MediaQuery.of(context).size.height; // LINT
+
+    return Container(
+      width: width,
+      height: height,
+      padding: EdgeInsets.all(10),
+      child: Column(
+        children: [
+          Text('Screen size: ${size.width} x ${size.height}'),
+          Text('Orientation: $orientation'),
+          Text('Device pixel ratio: $devicePixelRatio'),
+          Text('Platform brightness: $platformBrightness'),
+        ],
+      ),
+    );
+  }
+
+  void otherMethod(BuildContext context) {
+    // ❌ Bad: Various patterns that should trigger lint
+    if (MediaQuery.of(context).orientation == Orientation.portrait) {
+      // LINT
+      print('Portrait mode');
+    }
+
+    switch (MediaQuery.of(context).platformBrightness) {
+      // LINT
+      case Brightness.light:
+        print('Light theme');
+        break;
+      case Brightness.dark:
+        print('Dark theme');
+        break;
+    }
+
+    // ❌ Bad: In expressions
+    final isSmallScreen = MediaQuery.of(context).size.width < 600; // LINT
+    final hasNotch = MediaQuery.of(context).viewPadding.top > 20; // LINT
+
+    // ✅ Good: Using direct methods
+    final goodIsSmallScreen = MediaQuery.sizeOf(context).width < 600;
+    final goodHasNotch = MediaQuery.viewPaddingOf(context).top > 20;
+  }
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule_test.dart
@@ -1,0 +1,84 @@
+import 'package:dart_code_linter/src/analyzers/lint_analyzer/models/severity.dart';
+import 'package:dart_code_linter/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule.dart';
+import 'package:test/test.dart';
+
+import '../../../../../helpers/rule_test_helper.dart';
+
+const _examplePath = 'prefer_media_query_direct_access/examples/example.dart';
+
+void main() {
+  group('PreferMediaQueryDirectAccessRule', () {
+    test('initialization', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_examplePath);
+      final issues = PreferMediaQueryDirectAccessRule().check(unit);
+
+      RuleTestHelper.verifyInitialization(
+        issues: issues,
+        ruleId: 'prefer-media-query-direct-access',
+        severity: Severity.style,
+      );
+    });
+
+    test('reports about found issues', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_examplePath);
+      final issues = PreferMediaQueryDirectAccessRule().check(unit);
+
+      // Verify that we found the expected number of MediaQuery.of(context).property issues
+      expect(issues.length, greaterThan(20)); // Should find many issues
+
+      for (final issue in issues) {
+        expect(
+          issue.message,
+          equals(
+            'Prefer direct access to MediaQuery properties for better code readability.',
+          ),
+        );
+        expect(issue.ruleId, equals('prefer-media-query-direct-access'));
+      }
+    });
+
+    test('reports correct message', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_examplePath);
+      final issues = PreferMediaQueryDirectAccessRule().check(unit);
+
+      expect(issues.isNotEmpty, isTrue);
+      expect(
+        issues.first.message,
+        equals(
+          'Prefer direct access to MediaQuery properties for better code readability.',
+        ),
+      );
+    });
+
+    test('provides replacement suggestions', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_examplePath);
+      final issues = PreferMediaQueryDirectAccessRule().check(unit);
+
+      expect(issues.isNotEmpty, isTrue);
+
+      // Check that suggestions are provided
+      for (final issue in issues) {
+        expect(issue.suggestion, isNotNull);
+        expect(
+          issue.suggestion!.comment,
+          equals('Consider accessing MediaQuery properties directly.'),
+        );
+        expect(issue.suggestion!.replacement, contains('Of'));
+      }
+    });
+
+    test('accepts custom configuration', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_examplePath);
+      final rule = PreferMediaQueryDirectAccessRule({
+        'severity': 'warning',
+      });
+      final issues = rule.check(unit);
+
+      RuleTestHelper.verifyInitialization(
+        issues: issues,
+        ruleId: 'prefer-media-query-direct-access',
+        severity: Severity.warning,
+      );
+    });
+  });
+}

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -1,9 +1,9 @@
 name: dart_code_linter_analyzer_plugin_loader
 description: This pubspec determines the version of the analyzer plugin to load.
-version: 3.1.0-beta.2
+version: 3.1.0-beta.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  dart_code_linter: 3.1.0-beta.2
+  dart_code_linter: 3.1.0-beta.3


### PR DESCRIPTION
### New lint rule: MediaQuery direct access

* Added `prefer-media-query-direct-access` rule implementation in `lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule.dart` and its visitor in `visitor.dart`. [[1]](diffhunk://#diff-be1b397ccb8219fbc57faaf2eba58b2df668d1425efacdf79910535e30af3efcR1-R50) [[2]](diffhunk://#diff-e69a53f2a69131d97cd7c7b3f83e96df11660a39355662bcd042e5d93c4f4ddcR1-R37)
* Registered the new rule in the rules factory (`rules_factory.dart`). [[1]](diffhunk://#diff-43a2b17e36884c352e7c7cdddf39fd14226945324dda115127eaeb090bfc813dR72) [[2]](diffhunk://#diff-43a2b17e36884c352e7c7cdddf39fd14226945324dda115127eaeb090bfc813dR167)
* Enabled the rule in `analysis_options.yaml` and `example/analysis_options.yaml` for demonstration and testing. [[1]](diffhunk://#diff-9a967a7bb0393381dfdf9cce102a9cea39146829ab8b38e983d54ac8827486bcR85) [[2]](diffhunk://#diff-ef52b1226c697a95c613aacbd255ab4655f91a7d19c31fde92171b5c42e96771R62)

### Version and metadata updates

* Bumped package version to `3.1.0-beta.3` in `pubspec.yaml`, `lib/src/version.dart`, and `tools/analyzer_plugin/pubspec.yaml`. [[1]](diffhunk://#diff-389218715db21eae82edc77d255cd5fdcbab37f3a3d482b84aa82c75a9f9d52eL1-R1) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L2-R5) [[3]](diffhunk://#diff-7afa4a9ab8509b7e8001c2394a9ed84db94698bee93f9e6f6e991453415502ecL3-R9)
* Added changelog entry for the new rule in `CHANGELOG.md`.

### Example app changes

* Updated `example/lib/main.dart` to demonstrate MediaQuery direct access and integrate the new rule's recommendations. [[1]](diffhunk://#diff-72fd825ad17ce7800a2078e06f0dff1e12836ee59760465e78d9a5d222cebd15L45-R48) [[2]](diffhunk://#diff-72fd825ad17ce7800a2078e06f0dff1e12836ee59760465e78d9a5d222cebd15L57-R60) [[3]](diffhunk://#diff-72fd825ad17ce7800a2078e06f0dff1e12836ee59760465e78d9a5d222cebd15L74-R79)