### PR TITLE
Fix MediaQueryAccess rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.0
+- Add rule `prefer-media-query-direct-access`.
+- Add rule `prefer-named-record-fields`.
+
 ## 3.1.0-beta.3
 - Add rule `prefer-media-query-direct-access`.
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule.dart
@@ -12,15 +12,17 @@ part 'visitor.dart';
 
 class PreferMediaQueryDirectAccessRule extends DartRule {
   static const ruleId = 'prefer-media-query-direct-access';
-  static const warningMessage =
-      'Prefer direct access to MediaQuery properties for better code readability.';
+  static const warningMessage = '''
+      Prefer using this function over getting the attribute directly from the MediaQueryData returned from of, 
+      because using this function will only rebuild the context when this specific attribute changes, 
+      not when any attribute changes.''';
   static const replaceComment =
       'Consider accessing MediaQuery properties directly.';
 
   PreferMediaQueryDirectAccessRule([Map<String, Object> config = const {}])
       : super(
           id: ruleId,
-          severity: readSeverity(config, Severity.style),
+          severity: readSeverity(config, Severity.performance),
           excludes: readExcludes(config),
           includes: readIncludes(config),
         );
@@ -38,9 +40,12 @@ class PreferMediaQueryDirectAccessRule extends DartRule {
         ));
   }
 
-  Replacement _createReplacement(MethodInvocation node) {
-    final propertyName = node.methodName.name;
-    final replacement = '.${propertyName}Of';
+  Replacement _createReplacement(PropertyAccess node) {
+    final propertyName = node.propertyName.name;
+    final target = node.target as MethodInvocation;
+    final context = target.argumentList.arguments.first;
+
+    final replacement = 'MediaQuery.${propertyName}Of($context)';
 
     return Replacement(
       comment: replaceComment,

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/visitor.dart
@@ -1,37 +1,51 @@
 part of 'prefer_media_query_direct_access_rule.dart';
 
 class _Visitor extends RecursiveAstVisitor<void> {
-  final _mediaQueryUsages = <MethodInvocation>[];
+  final _mediaQueryUsages = <PropertyAccess>[];
 
-  Iterable<MethodInvocation> get mediaQueryUsages => _mediaQueryUsages;
+  Iterable<PropertyAccess> get mediaQueryUsages => _mediaQueryUsages;
 
   @override
-  void visitMethodInvocation(MethodInvocation node) {
-    super.visitMethodInvocation(node);
+  void visitPropertyAccess(PropertyAccess node) {
+    super.visitPropertyAccess(node);
 
-    if (_isMediaQueryUsage(node)) {
+    if (_isMediaQueryPropertyAccess(node)) {
       _mediaQueryUsages.add(node);
     }
   }
 
-  bool _isMediaQueryUsage(MethodInvocation node) {
+  bool _isMediaQueryPropertyAccess(PropertyAccess node) {
     final target = node.target;
-    final methodName = node.methodName.name;
+    final propertyName = node.propertyName.name;
 
-    return target is SimpleIdentifier &&
-        target.name == 'MediaQuery' &&
-        (methodName == 'of' ||
-            methodName == 'size' ||
-            methodName == 'padding' ||
-            methodName == 'viewInsets' ||
-            methodName == 'viewPadding' ||
-            methodName == 'orientation' ||
-            methodName == 'devicePixelRatio' ||
-            methodName == 'textScaleFactor' ||
-            methodName == 'platformBrightness' ||
-            methodName == 'accessibleNavigation' ||
-            methodName == 'invertColors' ||
-            methodName == 'highContrast' ||
-            methodName == 'disableAnimations');
+    if (target is MethodInvocation &&
+        target.target is SimpleIdentifier &&
+        (target.target as SimpleIdentifier).name == 'MediaQuery' &&
+        target.methodName.name == 'of') {
+      return _hasDirectAccessMethod(propertyName);
+    }
+
+    return false;
+  }
+
+  bool _hasDirectAccessMethod(String propertyName) {
+    const availableProperties = {
+      'size',
+      'padding',
+      'viewInsets',
+      'viewPadding',
+      'orientation',
+      'devicePixelRatio',
+      'textScaleFactor',
+      'platformBrightness',
+      'systemGestureInsets',
+      'accessibleNavigation',
+      'invertColors',
+      'highContrast',
+      'disableAnimations',
+      'boldText',
+    };
+
+    return availableProperties.contains(propertyName);
   }
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '3.1.0-beta.3';
+const packageVersion = '3.1.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_code_linter
-version: 3.1.0-beta.3
+version: 3.1.0
 description: Dart Code Linter is a software analytics tool that helps developers analyse and improve software quality. Dart Code Linter is based on a fork of Dart Code Metrics.
 repository: https://github.com/bancolombia/dart-code-linter
 issue_tracker: https://github.com/bancolombia/dart-code-linter/issues

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule_test.dart
@@ -8,6 +8,11 @@ const _examplePath = 'prefer_media_query_direct_access/examples/example.dart';
 
 void main() {
   group('PreferMediaQueryDirectAccessRule', () {
+    const message = '''
+      Prefer using this function over getting the attribute directly from the MediaQueryData returned from of, 
+      because using this function will only rebuild the context when this specific attribute changes, 
+      not when any attribute changes.''';
+
     test('initialization', () async {
       final unit = await RuleTestHelper.resolveFromFile(_examplePath);
       final issues = PreferMediaQueryDirectAccessRule().check(unit);
@@ -15,7 +20,7 @@ void main() {
       RuleTestHelper.verifyInitialization(
         issues: issues,
         ruleId: 'prefer-media-query-direct-access',
-        severity: Severity.style,
+        severity: Severity.performance,
       );
     });
 
@@ -23,14 +28,13 @@ void main() {
       final unit = await RuleTestHelper.resolveFromFile(_examplePath);
       final issues = PreferMediaQueryDirectAccessRule().check(unit);
 
-      // Verify that we found the expected number of MediaQuery.of(context).property issues
-      expect(issues.length, greaterThan(20)); // Should find many issues
+      expect(issues.length, greaterThan(20));
 
       for (final issue in issues) {
         expect(
           issue.message,
           equals(
-            'Prefer direct access to MediaQuery properties for better code readability.',
+            message,
           ),
         );
         expect(issue.ruleId, equals('prefer-media-query-direct-access'));
@@ -45,7 +49,7 @@ void main() {
       expect(
         issues.first.message,
         equals(
-          'Prefer direct access to MediaQuery properties for better code readability.',
+          message,
         ),
       );
     });

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -1,9 +1,9 @@
 name: dart_code_linter_analyzer_plugin_loader
 description: This pubspec determines the version of the analyzer plugin to load.
-version: 3.1.0-beta.3
+version: 3.1.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  dart_code_linter: 3.1.0-beta.3
+  dart_code_linter: 3.1.0


### PR DESCRIPTION
This pull request finalizes the release of version 3.1.0, promoting it from beta and updating the `prefer-media-query-direct-access` lint rule for improved accuracy and guidance. The main changes are grouped into release updates and improvements to lint rule logic.

**Release updates:**

* Updated version numbers from `3.1.0-beta.3` to `3.1.0` in `pubspec.yaml`, `lib/src/version.dart`, `tools/analyzer_plugin/pubspec.yaml`, and documented the release in `CHANGELOG.md`. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L2-R2) [[2]](diffhunk://#diff-389218715db21eae82edc77d255cd5fdcbab37f3a3d482b84aa82c75a9f9d52eL1-R1) [[3]](diffhunk://#diff-7afa4a9ab8509b7e8001c2394a9ed84db94698bee93f9e6f6e991453415502ecL3-R9) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6)

**Lint rule improvements:**

* Enhanced the warning message in `prefer_media_query_direct_access_rule.dart` to better explain the benefits of direct property access and changed the severity from style to performance.
* Refactored the visitor logic in `visitor.dart` to detect `PropertyAccess` instead of `MethodInvocation`, improving how usages of `MediaQuery.of(context).property` are identified.
* Updated the replacement logic in `prefer_media_query_direct_access_rule.dart` to suggest using the corresponding `MediaQuery.propertyOf(context)` function for direct access.