### PR TITLE
fix: change rule category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.1
+- Changed `prefer-media-query-direct-access` to `FlutterRule`.
+
 ## 3.1.0
 - Add rule `prefer-media-query-direct-access`.
 - Add rule `prefer-named-record-fields`.

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_media_query_direct_access/prefer_media_query_direct_access_rule.dart
@@ -5,12 +5,12 @@ import '../../../../../../lint_analyzer.dart';
 import '../../../../../utils/node_utils.dart';
 import '../../../lint_utils.dart';
 import '../../../models/internal_resolved_unit_result.dart';
-import '../../models/dart_rule.dart';
+import '../../models/flutter_rule.dart';
 import '../../rule_utils.dart';
 
 part 'visitor.dart';
 
-class PreferMediaQueryDirectAccessRule extends DartRule {
+class PreferMediaQueryDirectAccessRule extends FlutterRule {
   static const ruleId = 'prefer-media-query-direct-access';
   static const warningMessage = '''
       Prefer using this function over getting the attribute directly from the MediaQueryData returned from of, 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_code_linter
-version: 3.1.0
+version: 3.1.1
 description: Dart Code Linter is a software analytics tool that helps developers analyse and improve software quality. Dart Code Linter is based on a fork of Dart Code Metrics.
 repository: https://github.com/bancolombia/dart-code-linter
 issue_tracker: https://github.com/bancolombia/dart-code-linter/issues

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -1,9 +1,9 @@
 name: dart_code_linter_analyzer_plugin_loader
 description: This pubspec determines the version of the analyzer plugin to load.
-version: 3.1.0
+version: 3.1.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  dart_code_linter: 3.1.0
+  dart_code_linter: 3.1.1


### PR DESCRIPTION
This pull request updates the `prefer-media-query-direct-access` rule to extend from `FlutterRule` instead of `DartRule`, reflecting its intended usage with Flutter code. It also bumps the package version to `3.1.1` across the main package and analyzer plugin loader, and documents the change in the changelog.

Rule update:

* Changed the base class of `PreferMediaQueryDirectAccessRule` from `DartRule` to `FlutterRule` in `prefer_media_query_direct_access_rule.dart`, ensuring the rule is correctly categorized for Flutter projects.

Version updates:

* Updated the version to `3.1.1` in `pubspec.yaml` and `tools/analyzer_plugin/pubspec.yaml` to reflect the rule change. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L2-R2) [[2]](diffhunk://#diff-7afa4a9ab8509b7e8001c2394a9ed84db94698bee93f9e6f6e991453415502ecL3-R9)

Documentation:

* Added a changelog entry for version `3.1.1` to document the rule's base class change.