### PR TITLE
bump analyzer to ^8.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,11 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
-      - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v3
+      - name: Setup Flutter
+        uses: bancolombia/flutter-setup-action@v1.1
         with:
-          channel: stable
-          version: 3.32.0
+          channel: 'stable'
+          flutter-version: '3.35.0'
       - name: Install dependencies
         run: dart pub get
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 3.2.0
+## 3.2.0-alpha.1
 - Add rule `use-design-system-items`.
 - Add rule `only-barrel-import`.
 - Allow to specify more than one suggestion for each rule.
+- Bump `analyzer` to ^8.0.0
 
 ## 3.1.1
 - Changed `prefer-media-query-direct-access` to `FlutterRule`.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   example_core:
     path: ./example_core
+  dart_style: 3.1.2
 
 dev_dependencies:
   #dart_code_linter: <USE-THE-LATEST-VERSION>

--- a/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_method.dart
+++ b/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_method.dart
@@ -53,7 +53,7 @@ class LongMethod extends Pattern {
                           metricValue.metricsId ==
                               SourceLinesOfCodeMetric.metricId &&
                           metricValue.value >
-                              _sourceLinesOfCodeMetricThreshold!)
+                              _sourceLinesOfCodeMetricThreshold)
                       .map(
                         (metricValue) => createIssue(
                           pattern: this,

--- a/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_parameter_list.dart
+++ b/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_parameter_list.dart
@@ -50,7 +50,7 @@ class LongParameterList extends Pattern {
                           metricValue.metricsId ==
                               NumberOfParametersMetric.metricId &&
                           metricValue.value >
-                              _numberOfParametersMetricThreshold!)
+                              _numberOfParametersMetricThreshold)
                       .map(
                         (metricValue) => createIssue(
                           pattern: this,

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/always_remove_listener/always_remove_listener_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/always_remove_listener/always_remove_listener_rule.dart
@@ -2,7 +2,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/always_remove_listener/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/always_remove_listener/visitor.dart
@@ -70,7 +70,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
           removedListeners,
           disposedListeners,
           target.name,
-          target.staticElement,
+          target.element,
         );
       }
     }
@@ -84,7 +84,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
   ) {
     for (final addedListener in addedListeners) {
       final target = addedListener.realTarget;
-      final widgetType = widgetParameter.declaredElement?.type;
+      final widgetType = widgetParameter.declaredFragment?.element.type;
 
       if (target is PrefixedIdentifier &&
           _isRootWidget(target.prefix.staticType, widgetType)) {
@@ -101,7 +101,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
           removedListeners,
           disposedListeners,
           targetName,
-          target.staticElement,
+          target.element,
         );
       } else if (target is Identifier) {
         _compareInvocation(
@@ -109,7 +109,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
           removedListeners,
           disposedListeners,
           target.name,
-          target.staticElement,
+          target.element,
         );
       }
     }
@@ -120,19 +120,33 @@ class _Visitor extends RecursiveAstVisitor<void> {
     Iterable<MethodInvocation> removedListeners,
     Iterable<MethodInvocation> disposedListeners,
     String? targetName,
-    Element? staticElement,
+    Element2? element,
   ) {
     final removedListener = removedListeners
-        .where((invocation) =>
-            _haveSameTargets(invocation, targetName, staticElement))
+        .where(
+          (invocation) => _haveSameTargets(
+            invocation,
+            targetName,
+            element,
+          ),
+        )
         .toList();
 
-    final haveNotSameCallbacks = !removedListener
-        .any((listener) => _haveSameCallbacks(addedListener, listener));
+    final haveNotSameCallbacks = !removedListener.any(
+      (listener) => _haveSameCallbacks(
+        addedListener,
+        listener,
+      ),
+    );
 
     final disposedListener = disposedListeners
-        .where((invocation) =>
-            _haveSameTargets(invocation, targetName, staticElement))
+        .where(
+          (invocation) => _haveSameTargets(
+            invocation,
+            targetName,
+            element,
+          ),
+        )
         .toList();
 
     if ((removedListener.isEmpty || haveNotSameCallbacks) &&
@@ -149,15 +163,14 @@ class _Visitor extends RecursiveAstVisitor<void> {
   bool _haveSameTargets(
     MethodInvocation removedListener,
     String? targetName,
-    Element? staticElement,
+    Element2? element,
   ) {
     final removedTarget = removedListener.realTarget;
 
     return removedTarget is Identifier &&
         removedTarget.name == targetName &&
-        (removedTarget.staticElement == staticElement ||
-            removedTarget.staticElement?.declaration ==
-                staticElement?.declaration);
+        (removedTarget.element == element ||
+            removedTarget.element?.firstFragment == element?.firstFragment);
   }
 
   bool _haveSameCallbacks(
@@ -170,13 +183,11 @@ class _Visitor extends RecursiveAstVisitor<void> {
     return addedCallback is Identifier &&
         removedCallback is Identifier &&
         addedCallback.name == removedCallback.name &&
-        addedCallback.staticElement == removedCallback.staticElement;
+        addedCallback.element == removedCallback.element;
   }
 
   bool _isRootWidget(DartType? type, DartType? rootType) =>
-      type != null &&
-      type.getDisplayString(withNullability: false) ==
-          rootType?.getDisplayString(withNullability: false);
+      type != null && type.getDisplayString() == rootType?.getDisplayString();
 }
 
 class _ListenableVisitor extends RecursiveAstVisitor<void> {

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/arguments_ordering/arguments_ordering_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/arguments_ordering/arguments_ordering_rule.dart
@@ -3,6 +3,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:collection/collection.dart';
 
 import '../../../../../utils/node_utils.dart';

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/arguments_ordering/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/arguments_ordering/visitor.dart
@@ -19,25 +19,25 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
     _checkOrder(
       node.argumentList,
-      node.constructorName.staticElement?.parameters ?? [],
+      node.constructorName.element!.formalParameters,
     );
   }
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
     super.visitMethodInvocation(node);
-    final staticElement = node.methodName.staticElement;
-    if (staticElement is FunctionElement) {
+    final element = node.methodName.element;
+    if (element is TopLevelFunctionElement) {
       _checkOrder(
         node.argumentList,
-        staticElement.parameters,
+        element.formalParameters,
       );
     }
   }
 
   void _checkOrder(
     ArgumentList argumentList,
-    List<ParameterElement> parameters,
+    List<FormalParameterElement> parameters,
   ) {
     final sortedArguments = argumentList.arguments.sorted((a, b) {
       if (a is! NamedExpression && b is! NamedExpression) {
@@ -86,7 +86,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
   }
 
   static int _parameterIndex(
-    List<ParameterElement> parameters,
+    List<FormalParameterElement> parameters,
     NamedExpression argumentExpression,
   ) =>
       parameters.indexWhere(

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_dynamic/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_dynamic/visitor.dart
@@ -26,7 +26,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
   @override
   void visitClassDeclaration(ClassDeclaration node) {
     if (node.extendsClause != null) {
-      NamedType? baseType = node.extendsClause?.superclass;
+      final baseType = node.extendsClause?.superclass;
       if (baseType is Identifier && baseType?.name2.toString() == 'dynamic') {
         _nodes.add(node);
       } else {

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/visitor.dart
@@ -9,12 +9,13 @@ class _Visitor extends RecursiveAstVisitor<void> {
   void visitVariableDeclaration(VariableDeclaration node) {
     super.visitVariableDeclaration(node);
 
-    if (node.declaredFragment?.element is CompilationUnitElement) {
+    final element = node.declaredFragment?.element;
+
+    if (element is LibraryFragment) {
       if (_isNodeValid(node)) {
         _declarations.add(node);
       }
-    } else if ((node.declaredElement?.isStatic ?? false) &&
-        _isNodeValid(node)) {
+    } else if ((element?.isStatic ?? false) && _isNodeValid(node)) {
       _declarations.add(node);
     }
   }
@@ -22,5 +23,5 @@ class _Visitor extends RecursiveAstVisitor<void> {
   bool _isNodeValid(VariableDeclaration node) =>
       !node.isFinal &&
       !node.isConst &&
-      !(node.declaredElement?.isPrivate ?? false);
+      !(node.declaredFragment?.element.isPrivate ?? false);
 }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_ignoring_return_values/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_ignoring_return_values/visitor.dart
@@ -25,7 +25,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
       (expression is PropertyAccess &&
           _hasUnusedResult(expression.staticType)) ||
       (expression is PrefixedIdentifier &&
-          expression.staticElement?.kind == ElementKind.GETTER &&
+          expression.element?.kind == ElementKind.GETTER &&
           _hasUnusedResult(expression.staticType));
 
   bool _isAwaitWithUnusedResult(Expression expression) =>

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_late_keyword/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_late_keyword/visitor.dart
@@ -28,6 +28,6 @@ class _Visitor extends RecursiveAstVisitor<void> {
       allowInitialized && node.initializer != null;
 
   bool _hasIgnoredType(VariableDeclaration node) => ignoredTypes.contains(
-        node.declaredElement?.type.getDisplayString(withNullability: false),
+        node.declaredFragment?.element.type.getDisplayString(),
       );
 }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_missing_enum_constant_in_map/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_missing_enum_constant_in_map/visitor.dart
@@ -20,9 +20,9 @@ class _Visitor extends RecursiveAstVisitor<void> {
       if (element is MapLiteralEntry) {
         final key = element.key;
         if (key is PrefixedIdentifier) {
-          final staticElement = key.prefix.staticElement;
-          if (staticElement is EnumElement) {
-            enumElement ??= staticElement;
+          final element = key.prefix.element;
+          if (element is EnumElement) {
+            enumElement ??= element;
             usages.add(key.identifier.name);
           }
         }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/visitor.dart
@@ -53,7 +53,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
     node.visitChildren(declarationsVisitor);
 
     final names = declarationsVisitor.declarations
-        .map((declaration) => declaration.declaredElement?.name)
+        .map((declaration) => declaration.declaredFragment?.name)
         .whereType<String>()
         .toSet();
 
@@ -88,7 +88,7 @@ class _InvocationsVisitor extends RecursiveAstVisitor<void> {
     final grandParent = node.parent?.parent;
     if (grandParent is FunctionExpression &&
         grandParent.parent is! NamedExpression) {
-      return grandParent.staticParameterElement?.declaration.name == 'builder';
+      return grandParent.declaredFragment?.element.name == 'builder';
     }
 
     final expression = node.thisOrAncestorOfType<NamedExpression>();

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/visitor.dart
@@ -88,7 +88,7 @@ class _InvocationsVisitor extends RecursiveAstVisitor<void> {
     final grandParent = node.parent?.parent;
     if (grandParent is FunctionExpression &&
         grandParent.parent is! NamedExpression) {
-      return grandParent.declaredFragment?.element.name == 'builder';
+      return grandParent.declaredFragment?.enclosingFragment?.name == 'build';
     }
 
     final expression = node.thisOrAncestorOfType<NamedExpression>();

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_unused_parameters/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_unused_parameters/visitor.dart
@@ -63,7 +63,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
     for (final parameter in parameters) {
       final name = parameter.name;
       if (name != null &&
-          !allIdentifierElements.contains(parameter.declaredElement)) {
+          !allIdentifierElements
+              .contains(parameter.declaredFragment?.element)) {
         result.add(parameter);
       }
     }
@@ -95,7 +96,7 @@ class _IdentifiersVisitor extends RecursiveAstVisitor<void> {
   void visitSimpleIdentifier(SimpleIdentifier node) {
     super.visitSimpleIdentifier(node);
 
-    final element = node.staticElement;
+    final element = node.element;
     if (element != null) {
       elements.add(element);
     }
@@ -112,7 +113,7 @@ class _InvocationsVisitor extends RecursiveAstVisitor<void> {
   @override
   void visitSimpleIdentifier(SimpleIdentifier node) {
     if (node.name == methodName &&
-        node.staticElement is MethodElement &&
+        node.element is MethodElement &&
         node.parent is ArgumentList) {
       hasTearOffInvocations = true;
     }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/ban_name/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/ban_name/visitor.dart
@@ -31,7 +31,7 @@ class _Visitor extends GeneralizingAstVisitor<void> {
 
   @override
   void visitDeclaration(Declaration node) {
-    final name = node.declaredElement?.displayName;
+    final name = node.declaredFragment?.name;
     if (name != null) {
       _visitIdent(node, name);
     }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/check_for_equals_in_render_object_setters/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/check_for_equals_in_render_object_setters/visitor.dart
@@ -82,7 +82,7 @@ class _SettersVisitor extends GeneralizingAstVisitor<void> {
 
   bool _usesParameter(Expression expression) =>
       expression is SimpleIdentifier &&
-      expression.staticElement is ParameterElement;
+      expression.element is FormalParameterElement;
 }
 
 class _ReturnVisitor extends RecursiveAstVisitor<void> {

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/list_all_equatable_fields/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/list_all_equatable_fields/visitor.dart
@@ -60,7 +60,6 @@ class _Visitor extends GeneralizingAstVisitor<void> {
   }
 
   Set<String> _getParentFields(DartType? classType) {
-    // ignore: deprecated_member_use
     final element = classType?.element;
     if (element is! ClassElement) {
       return {};
@@ -74,7 +73,7 @@ class _Visitor extends GeneralizingAstVisitor<void> {
               !field.isPrivate &&
               field.name != 'hashCode',
         )
-        .map((field) => field.name)
+        .map((field) => field.name ?? '')
         .toSet();
   }
 
@@ -84,13 +83,12 @@ class _Visitor extends GeneralizingAstVisitor<void> {
   bool _isSubclassOfEquatable(DartType? type) =>
       type is InterfaceType && type.allSupertypes.any(_isEquatable);
 
-  bool _isEquatable(DartType? type) =>
-      type?.getDisplayString(withNullability: false) == 'Equatable';
+  bool _isEquatable(DartType? type) => type?.getDisplayString() == 'Equatable';
 
   bool _isEquatableMixin(DartType? type) =>
       // ignore: deprecated_member_use
       type?.element is MixinElement &&
-      type?.getDisplayString(withNullability: false) == 'EquatableMixin';
+      type?.getDisplayString() == 'EquatableMixin';
 
   bool _isSubclassOfEquatableMixin(DartType? type) {
     // ignore: deprecated_member_use

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_enums_by_name/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_enums_by_name/visitor.dart
@@ -20,7 +20,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
   }
 
   bool _isEnum(SimpleIdentifier prefix) =>
-      prefix.staticElement?.kind == ElementKind.ENUM;
+      prefix.element?.kind == ElementKind.ENUM;
 
   bool _hasValuesTarget(SimpleIdentifier identifier) =>
       identifier.name == 'values';

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
@@ -72,7 +72,9 @@ class _InstanceCreationVisitor extends RecursiveAstVisitor<void> {
   }
 
   bool _isFlutterBuilder(FunctionExpression expression) {
-    if (!isWidgetOrSubclass(expression.declaredElement?.returnType)) {
+    if (!isWidgetOrSubclass(
+      expression.declaredFragment?.element.returnType,
+    )) {
       return false;
     }
 
@@ -80,7 +82,9 @@ class _InstanceCreationVisitor extends RecursiveAstVisitor<void> {
 
     return formalParameters == null ||
         formalParameters.isNotEmpty &&
-            isBuildContext(formalParameters.first.declaredElement?.type);
+            isBuildContext(
+              formalParameters.first.declaredFragment?.element.type,
+            );
   }
 
   bool _isNotIgnored(Expression argument) =>

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_first_or_null/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_first_or_null/visitor.dart
@@ -23,13 +23,15 @@ class _Visitor extends RecursiveAstVisitor<void> {
     super.visitMethodInvocation(node);
 
     if (isIterableOrSubclass(node.realTarget?.staticType)) {
-      if (node.methodName.name == 'elementAt') {
+      final name = node.methodName.name;
+
+      if (name == 'elementAt') {
         final arg = node.argumentList.arguments.first;
 
         if (arg is IntegerLiteral && arg.value == 0) {
           _expressions.add(node);
         }
-      } else if (node.methodName.name == 'first') {
+      } else if (name == 'first') {
         _expressions.add(node);
       }
     }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
@@ -46,7 +46,7 @@ class _BlockVisitor extends RecursiveAstVisitor<void> {
     }
 
     if (target is PrefixedIdentifier) {
-      final element = target.identifier.staticElement;
+      final element = target.identifier.element;
       if (element is EnumElement || element is ClassElement) {
         return;
       }
@@ -170,7 +170,7 @@ class _BlockVisitor extends RecursiveAstVisitor<void> {
             argument is NamedExpression ? argument.expression : argument;
 
         if (expression is SimpleIdentifier) {
-          final element = expression.staticElement;
+          final element = expression.element;
 
           return element is VariableElement &&
               !element.isConst &&

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_trailing_comma/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_trailing_comma/visitor.dart
@@ -56,7 +56,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
     if (last.endToken.next?.type != TokenType.COMMA &&
         (!_isLastItemMultiLine(last, leftBracket, rightBracket) &&
                 _getLineNumber(leftBracket) != _getLineNumber(rightBracket) ||
-            _breakpoint != null && nodes.length >= _breakpoint!)) {
+            _breakpoint != null && nodes.length >= _breakpoint)) {
       _nodes.add(last);
     }
   }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/tag_name/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/tag_name/visitor.dart
@@ -20,7 +20,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   void _checkField(FieldDeclaration node, VariableDeclaration fieldVariable) {
     final fieldName = fieldVariable.name.lexeme;
-    final fieldType = fieldVariable.declaredElement?.type;
+    final fieldType = fieldVariable.declaredFragment?.element.type;
 
     if (!(fieldType != null &&
         fieldType.isDartCoreString &&

--- a/lib/src/analyzers/unnecessary_nullable_analyzer/declarations_visitor.dart
+++ b/lib/src/analyzers/unnecessary_nullable_analyzer/declarations_visitor.dart
@@ -72,7 +72,7 @@ class DeclarationsVisitor extends RecursiveAstVisitor<void> {
 
   bool _hasNullableParameters(Iterable<FormalParameter> parameters) =>
       parameters.any((parameter) {
-        final type = parameter.declaredElement?.type;
+        final type = parameter.declaredFragment?.element.type;
 
         return type != null &&
                 (isNullableType(type) &&
@@ -86,7 +86,7 @@ class DeclarationsVisitor extends RecursiveAstVisitor<void> {
     Declaration node,
     Iterable<FormalParameter> parameters,
   ) {
-    final element = node.declaredElement;
+    final element = node.declaredFragment?.element;
 
     if (element != null) {
       declarations[element] = parameters;

--- a/lib/src/analyzers/unnecessary_nullable_analyzer/invocations_visitor.dart
+++ b/lib/src/analyzers/unnecessary_nullable_analyzer/invocations_visitor.dart
@@ -14,7 +14,7 @@ class InvocationsVisitor extends RecursiveAstVisitor<void> {
   void visitExportDirective(ExportDirective node) {
     super.visitExportDirective(node);
 
-    final uri = node.element?.uri;
+    final uri = node.libraryExport?.uri;
     if (uri is DirectiveUriWithSource) {
       invocationsUsages.exports.add(uri.source.fullName);
     }
@@ -25,7 +25,7 @@ class InvocationsVisitor extends RecursiveAstVisitor<void> {
     super.visitPropertyAccess(node);
 
     if (node.propertyName.staticType is FunctionType) {
-      _recordUsedElement(node.propertyName.staticElement, null);
+      _recordUsedElement(node.propertyName.element, null);
     }
   }
 
@@ -34,7 +34,7 @@ class InvocationsVisitor extends RecursiveAstVisitor<void> {
     super.visitPrefixedIdentifier(node);
 
     if (node.identifier.staticType is FunctionType) {
-      _recordUsedElement(node.identifier.staticElement, null);
+      _recordUsedElement(node.identifier.element, null);
     }
   }
 
@@ -42,21 +42,21 @@ class InvocationsVisitor extends RecursiveAstVisitor<void> {
   void visitMethodInvocation(MethodInvocation node) {
     super.visitMethodInvocation(node);
 
-    _recordUsedElement(node.methodName.staticElement, node.argumentList);
+    _recordUsedElement(node.methodName.element, node.argumentList);
   }
 
   @override
   void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
     super.visitFunctionExpressionInvocation(node);
 
-    _recordUsedElement(node.staticElement, node.argumentList);
+    _recordUsedElement(node.element, node.argumentList);
   }
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
     super.visitInstanceCreationExpression(node);
 
-    _recordUsedElement(node.constructorName.staticElement, node.argumentList);
+    _recordUsedElement(node.constructorName.element, node.argumentList);
   }
 
   /// Records use of a not prefixed [element].

--- a/lib/src/analyzers/unnecessary_nullable_analyzer/unnecessary_nullable_analyzer.dart
+++ b/lib/src/analyzers/unnecessary_nullable_analyzer/unnecessary_nullable_analyzer.dart
@@ -210,7 +210,7 @@ class UnnecessaryNullableAnalyzer {
     Iterable<FormalParameter> parameters,
   ) {
     final usages = invocationsUsage.elements[element];
-    final unit = element.thisOrAncestorOfType<CompilationUnitElement>();
+    final unit = element.firstFragment.libraryFragment?.element;
     if (usages == null || unit == null) {
       return null;
     }
@@ -245,7 +245,7 @@ class UnnecessaryNullableAnalyzer {
       (parameter) =>
           !_shouldIgnoreWidgetKey(parameter) &&
           !markedParameters.contains(parameter) &&
-          isNullableType(parameter.declaredElement?.type),
+          isNullableType(parameter.declaredFragment?.element.type),
     );
 
     if (unnecessaryNullable.isEmpty) {
@@ -254,7 +254,6 @@ class UnnecessaryNullableAnalyzer {
 
     return _createUnnecessaryNullableIssue(
       element as ElementImpl,
-      unit,
       unnecessaryNullable,
     );
   }
@@ -295,24 +294,25 @@ class UnnecessaryNullableAnalyzer {
 
   UnnecessaryNullableIssue _createUnnecessaryNullableIssue(
     ElementImpl element,
-    CompilationUnitElement unit,
     Iterable<FormalParameter> parameters,
   ) {
-    final offset = element.codeOffset!;
-    final lineInfo = unit.lineInfo;
-    final offsetLocation = lineInfo.getLocation(offset);
+    final libraryFragment = element.firstFragment.libraryFragment;
 
-    final sourceUrl = element.source!.uri;
+    final offset = element.firstFragment.codeOffset;
+    final lineInfo = libraryFragment?.lineInfo;
+    final offsetLocation = lineInfo?.getLocation(offset!);
+
+    final sourceUrl = libraryFragment?.source.uri;
 
     return UnnecessaryNullableIssue(
       declarationName: element.displayName,
       declarationType: element.kind.displayName,
       parameters: parameters.map((parameter) => parameter.toString()),
       location: SourceLocation(
-        offset,
+        offset!,
         sourceUrl: sourceUrl,
-        line: offsetLocation.lineNumber,
-        column: offsetLocation.columnNumber,
+        line: offsetLocation?.lineNumber,
+        column: offsetLocation?.columnNumber,
       ),
     );
   }
@@ -322,7 +322,9 @@ class UnnecessaryNullableAnalyzer {
 
     if (closestDeclaration is ConstructorDeclaration) {
       return parameter.name?.lexeme == 'key' &&
-          isWidgetOrSubclass(closestDeclaration.declaredElement?.returnType);
+          isWidgetOrSubclass(
+            closestDeclaration.declaredFragment?.element.returnType,
+          );
     }
 
     return false;

--- a/lib/src/analyzers/unused_code_analyzer/models/file_elements_usage.dart
+++ b/lib/src/analyzers/unused_code_analyzer/models/file_elements_usage.dart
@@ -13,6 +13,8 @@ class FileElementsUsage {
 
   final Map<Set<String>, Set<Element>> conditionalElements = {};
 
+  final Set<String> conditionalFiles = {};
+
   /// The map of referenced prefix elements and the elements that they prefix.
   final Map<PrefixElement, List<Element>> prefixMap = {};
 
@@ -21,6 +23,7 @@ class FileElementsUsage {
     usedExtensions.addAll(other.usedExtensions);
     exports.addAll(other.exports);
     conditionalElements.addAll(other.conditionalElements);
+    conditionalFiles.addAll(other.conditionalFiles);
     prefixMap.addAll(other.prefixMap);
   }
 }

--- a/lib/src/analyzers/unused_code_analyzer/public_code_visitor.dart
+++ b/lib/src/analyzers/unused_code_analyzer/public_code_visitor.dart
@@ -46,7 +46,7 @@ class PublicCodeVisitor extends GeneralizingAstVisitor<void> {
   }
 
   void _getTopLevelElement(Declaration node) {
-    final element = node.declaredElement;
+    final element = node.declaredFragment?.element;
 
     if (element != null) {
       topLevelElements.add(element);

--- a/lib/src/analyzers/unused_code_analyzer/unused_code_analyzer.dart
+++ b/lib/src/analyzers/unused_code_analyzer/unused_code_analyzer.dart
@@ -165,7 +165,7 @@ class UnusedCodeAnalyzer {
 
       for (final element in elements) {
         if (_isUnused(codeUsages, path, element)) {
-          final unit = element.thisOrAncestorOfType<CompilationUnitElement>();
+          final unit = element.firstFragment.libraryFragment;
           if (unit != null) {
             issues.add(_createUnusedCodeIssue(element as ElementImpl, unit));
           }
@@ -197,7 +197,7 @@ class UnusedCodeAnalyzer {
     }
 
     final usedLibrary = left.library;
-    final declaredSource = right?.librarySource;
+    final declaredSource = right?.firstFragment.libraryFragment?.source;
 
     // This is a hack to fix incorrect libraries resolution.
     // Should be removed after new analyzer version is available.
@@ -205,8 +205,8 @@ class UnusedCodeAnalyzer {
     return usedLibrary != null &&
         declaredSource != null &&
         left.name == right?.name &&
-        usedLibrary.units
-            .map((unit) => unit.source.fullName)
+        usedLibrary.fragments
+            .map((fragment) => fragment.source.fullName)
             .contains(declaredSource.fullName);
   }
 
@@ -224,13 +224,13 @@ class UnusedCodeAnalyzer {
 
   UnusedCodeIssue _createUnusedCodeIssue(
     ElementImpl element,
-    CompilationUnitElement unit,
+    LibraryFragment unit,
   ) {
-    final offset = element.codeOffset!;
+    final offset = element.firstFragment.codeOffset!;
     final lineInfo = unit.lineInfo;
     final offsetLocation = lineInfo.getLocation(offset);
 
-    final sourceUrl = element.source!.uri;
+    final sourceUrl = element.firstFragment.libraryFragment?.source.uri;
 
     return UnusedCodeIssue(
       declarationName: element.displayName,

--- a/lib/src/analyzers/unused_code_analyzer/used_code_visitor.dart
+++ b/lib/src/analyzers/unused_code_analyzer/used_code_visitor.dart
@@ -22,7 +22,10 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
 
         return (uri is DirectiveUriWithSource) ? uri.source.fullName : null;
       }).nonNulls;
-      final mainImport = node.element?.importedLibrary?.source.fullName;
+      final uri = node.libraryImport?.uri;
+
+      final mainImport =
+          uri is DirectiveUriWithLibrary ? uri.source.fullName : null;
 
       final allPaths = {if (mainImport != null) mainImport, ...paths};
 
@@ -40,7 +43,9 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
   void visitExportDirective(ExportDirective node) {
     super.visitExportDirective(node);
 
-    final path = node.element?.exportedLibrary?.source.fullName;
+    final uri = node.libraryExport?.uri;
+
+    final path = uri is DirectiveUriWithLibrary ? uri.source.fullName : null;
     if (path != null) {
       fileElementsUsage.exports.add(path);
     }
@@ -55,21 +60,21 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitBinaryExpression(BinaryExpression node) {
-    _recordIfExtensionMember(node.staticElement);
+    _recordIfExtensionMember(node.element);
 
     super.visitBinaryExpression(node);
   }
 
   @override
   void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
-    _recordIfExtensionMember(node.staticElement);
+    _recordIfExtensionMember(node.element);
 
     super.visitFunctionExpressionInvocation(node);
   }
 
   @override
   void visitIndexExpression(IndexExpression node) {
-    _recordIfExtensionMember(node.staticElement);
+    _recordIfExtensionMember(node.element);
 
     super.visitIndexExpression(node);
   }
@@ -84,14 +89,14 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
   @override
   void visitPrefixExpression(PrefixExpression node) {
     _recordAssignmentTarget(node, node.operand);
-    _recordIfExtensionMember(node.staticElement);
+    _recordIfExtensionMember(node.element);
 
     super.visitPrefixExpression(node);
   }
 
   @override
   void visitSimpleIdentifier(SimpleIdentifier node) {
-    _visitIdentifier(node, node.staticElement);
+    _visitIdentifier(node, node.element);
   }
 
   @override
@@ -153,7 +158,7 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
 
   void _recordIfExtensionMember(Element? element) {
     if (element != null) {
-      final enclosingElement = element.enclosingElement3;
+      final enclosingElement = element.enclosingElement;
       if (enclosingElement is ExtensionElement) {
         _recordUsedExtension(enclosingElement);
       }
@@ -161,7 +166,8 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
   }
 
   bool _recordConditionalElement(Element element) {
-    final elementPath = element.enclosingElement3?.source?.fullName;
+    final elementPath = element
+        .enclosingElement?.firstFragment.libraryFragment?.source.fullName;
     if (elementPath == null) {
       return false;
     }
@@ -215,8 +221,8 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
       return;
     }
 
-    final enclosingElement = element.enclosingElement3;
-    if (enclosingElement is CompilationUnitElement) {
+    final enclosingElement = element.enclosingElement;
+    if (enclosingElement is LibraryFragment) {
       _recordUsedElement(element);
     } else if (enclosingElement is ExtensionElement) {
       _recordUsedExtension(enclosingElement);

--- a/lib/src/analyzers/unused_code_analyzer/used_code_visitor.dart
+++ b/lib/src/analyzers/unused_code_analyzer/used_code_visitor.dart
@@ -17,23 +17,41 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
   @override
   void visitImportDirective(ImportDirective node) {
     if (node.configurations.isNotEmpty) {
-      final paths = node.configurations.map((config) {
-        final uri = config.resolvedUri;
+      final configPaths = node.configurations
+          .map((config) {
+            final uri = config.resolvedUri;
 
-        return (uri is DirectiveUriWithSource) ? uri.source.fullName : null;
-      }).nonNulls;
-      final uri = node.libraryImport?.uri;
+            return (uri is DirectiveUriWithSource) ? uri.source.fullName : null;
+          })
+          .nonNulls
+          .toSet();
 
-      final mainImport =
-          uri is DirectiveUriWithLibrary ? uri.source.fullName : null;
+      final mainUriString = node.uri.stringValue;
+      final compilationUnit = node.root as CompilationUnit;
+      final declaredFragment = compilationUnit.declaredFragment;
+      final currentSource = declaredFragment?.source;
 
-      final allPaths = {if (mainImport != null) mainImport, ...paths};
+      String? mainImport;
+      if (currentSource != null && mainUriString != null) {
+        try {
+          mainImport = currentSource.uri.resolve(mainUriString).toFilePath();
+        } catch (_) {
+          final uri = node.libraryImport?.uri;
+          if (uri is DirectiveUriWithLibrary) {
+            mainImport = uri.library.firstFragment.source.fullName;
+          }
+        }
+      }
+
+      final allPaths = {if (mainImport != null) mainImport, ...configPaths};
 
       fileElementsUsage.conditionalElements.update(
         allPaths,
         (conditionalElements) => conditionalElements,
         ifAbsent: () => {},
       );
+
+      fileElementsUsage.conditionalFiles.addAll(configPaths);
     }
 
     super.visitImportDirective(node);
@@ -45,7 +63,9 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
 
     final uri = node.libraryExport?.uri;
 
-    final path = uri is DirectiveUriWithLibrary ? uri.source.fullName : null;
+    final path = uri is DirectiveUriWithLibrary
+        ? uri.library.firstFragment.source.fullName
+        : null;
     if (path != null) {
       fileElementsUsage.exports.add(path);
     }
@@ -165,23 +185,19 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
     }
   }
 
-  bool _recordConditionalElement(Element element) {
+  void _recordConditionalElement(Element element) {
     final elementPath = element
         .enclosingElement?.firstFragment.libraryFragment?.source.fullName;
     if (elementPath == null) {
-      return false;
+      return;
     }
 
     final entries = fileElementsUsage.conditionalElements.entries;
     for (final conditionalElement in entries) {
       if (conditionalElement.key.contains(elementPath)) {
         conditionalElement.value.add(element);
-
-        return true;
       }
     }
-
-    return false;
   }
 
   /// Records use of a not prefixed [element].
@@ -217,12 +233,12 @@ class UsedCodeVisitor extends RecursiveAstVisitor<void> {
     }
 
     // Record elements that are imported with conditional imports
-    if (_recordConditionalElement(element)) {
-      return;
-    }
+    _recordConditionalElement(element);
 
     final enclosingElement = element.enclosingElement;
-    if (enclosingElement is LibraryFragment) {
+
+    if (enclosingElement is LibraryElement ||
+        enclosingElement is LibraryFragment) {
       _recordUsedElement(element);
     } else if (enclosingElement is ExtensionElement) {
       _recordUsedExtension(enclosingElement);

--- a/lib/src/analyzers/unused_files_analyzer/unused_files_visitor.dart
+++ b/lib/src/analyzers/unused_files_analyzer/unused_files_visitor.dart
@@ -49,15 +49,19 @@ class UnusedFilesVisitor extends GeneralizingAstVisitor<void> {
 
   String? _getAbsolutePath(UriBasedDirective node) {
     if (node is ImportDirective) {
-      return node.element?.importedLibrary?.source.fullName;
+      final uri = node.libraryImport?.uri;
+
+      return uri is DirectiveUriWithLibrary ? uri.source.fullName : null;
     }
 
     if (node is ExportDirective) {
-      return node.element?.exportedLibrary?.source.fullName;
+      final uri = node.libraryExport?.uri;
+
+      return uri is DirectiveUriWithLibrary ? uri.source.fullName : null;
     }
 
     if (node is PartDirective) {
-      final uri = node.element?.uri;
+      final uri = node.partInclude?.uri;
       if (uri is DirectiveUriWithSource) {
         return uri.source.fullName;
       }

--- a/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer.dart
+++ b/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer.dart
@@ -162,12 +162,9 @@ class UnusedL10nAnalyzer {
     String rootFolder, {
     String? overriddenClassName,
   }) {
-    final unit = classElement.thisOrAncestorOfType<CompilationUnitElement>();
-    if (unit == null) {
-      return null;
-    }
+    final unit = classElement.firstFragment.libraryFragment;
 
-    final lineInfo = unit.lineInfo;
+    final lineInfo = unit.element.firstFragment.lineInfo;
     // ignore: unnecessary_null_comparison
     if (lineInfo == null) {
       return null;
@@ -188,7 +185,7 @@ class UnusedL10nAnalyzer {
       return UnusedL10nFileReport(
         path: filePath,
         relativePath: relativePath,
-        className: overriddenClassName ?? classElement.name,
+        className: overriddenClassName ?? classElement.name!,
         issues: issues,
       );
     }
@@ -199,9 +196,9 @@ class UnusedL10nAnalyzer {
   Iterable<UnusedL10nIssue> _getUnusedAccessors(
     InterfaceElement classElement,
     Iterable<String> usages,
-    CompilationUnitElement unit,
+    LibraryFragment unit,
   ) {
-    final unusedAccessors = classElement.accessors
+    final unusedAccessors = classElement.fields
         .where((field) => !field.isPrivate && !usages.contains(field.name))
         .map((field) => field.isSynthetic ? field.nonSynthetic : field);
 
@@ -213,7 +210,7 @@ class UnusedL10nAnalyzer {
   Iterable<UnusedL10nIssue> _getUnusedMethods(
     InterfaceElement classElement,
     Iterable<String> usages,
-    CompilationUnitElement unit,
+    LibraryFragment unit,
   ) {
     final unusedMethods = classElement.methods
         .where((method) => !method.isPrivate && !usages.contains(method.name))
@@ -226,16 +223,16 @@ class UnusedL10nAnalyzer {
 
   UnusedL10nIssue _createL10nIssue(
     ElementImpl element,
-    CompilationUnitElement unit,
+    LibraryFragment unit,
   ) {
-    final offset = element.codeOffset!;
+    final offset = element.firstFragment.codeOffset!;
     final lineInfo = unit.lineInfo;
     final offsetLocation = lineInfo.getLocation(offset);
 
-    final sourceUrl = element.source!.uri;
+    final sourceUrl = unit.source.uri;
 
     final name = element is MethodElement
-        ? '${element.displayName}(${(element as MethodElement).parameters.join(', ')})'
+        ? '${element.displayName}(${(element as MethodElement).formalParameters.join(', ')})'
         : element.displayName;
 
     return UnusedL10nIssue(

--- a/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_visitor.dart
+++ b/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_visitor.dart
@@ -92,13 +92,13 @@ class UnusedL10nVisitor extends RecursiveAstVisitor<void> {
       target is SimpleIdentifier &&
       (_classPattern.hasMatch(target.name) ||
           _classPattern.hasMatch(
-            target.staticType?.getDisplayString(withNullability: false) ?? '',
+            target.staticType?.getDisplayString() ?? '',
           ));
 
   bool _matchConstructorOf(Expression? target) =>
       target is InstanceCreationExpression &&
       _classPattern.hasMatch(
-        target.staticType?.getDisplayString(withNullability: false) ?? '',
+        target.staticType?.getDisplayString() ?? '',
       ) &&
       target.constructorName.name?.name == 'of';
 
@@ -107,16 +107,16 @@ class UnusedL10nVisitor extends RecursiveAstVisitor<void> {
 
   bool _matchExtension(Expression? target) =>
       target is PrefixedIdentifier &&
-      target.staticElement?.enclosingElement3 is ExtensionElement;
+      target.element?.enclosingElement is ExtensionElement;
 
   bool _matchStaticGetter(Expression? target) =>
       target is PrefixedIdentifier &&
       _classPattern.hasMatch(
-        target.staticType?.getDisplayString(withNullability: false) ?? '',
+        target.staticType?.getDisplayString() ?? '',
       );
 
   void _addMemberInvocation(SimpleIdentifier target, String name) {
-    final staticElement = target.staticElement;
+    final staticElement = target.element;
 
     if (staticElement is VariableElement) {
       // ignore: deprecated_member_use
@@ -145,19 +145,18 @@ class UnusedL10nVisitor extends RecursiveAstVisitor<void> {
   ) {
     final staticElement =
         // ignore: deprecated_member_use
-        target.constructorName.staticElement?.enclosingElement3;
+        target.constructorName.element?.enclosingElement;
 
     _tryAddInvocation(staticElement, name);
   }
 
   void _addMemberInvocationOnAccessor(SimpleIdentifier target, String name) {
-    final staticElement =
-        target.staticElement?.enclosingElement3 as ExtensionElement;
+    final staticElement = target.element?.enclosingElement as ExtensionElement;
 
-    for (final element in staticElement.accessors) {
-      if (_classPattern.hasMatch(element.returnType.toString())) {
+    for (final element in staticElement.fields) {
+      if (_classPattern.hasMatch(element.getExtendedDisplayName())) {
         // ignore: deprecated_member_use
-        final declaredElement = element.returnType.element;
+        final declaredElement = element.type.element;
 
         _tryAddInvocation(declaredElement, name);
         break;

--- a/lib/src/utils/node_utils.dart
+++ b/lib/src/utils/node_utils.dart
@@ -44,7 +44,7 @@ bool isOverride(List<Annotation> metadata) => metadata.any(
     );
 
 bool haveSameParameterType(Expression left, Expression right) =>
-    left.staticParameterElement?.type == right.staticParameterElement?.type;
+    left.staticType == right.staticType;
 
 bool isEntrypoint(String name, NodeList<Annotation> metadata) =>
     name == 'main' ||

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ platforms:
   macos:
 
 dependencies:
-  analyzer: ^7.4.1
+  analyzer: ^8.0.0
   analyzer_plugin: ^0.13.0
   ansicolor: ^2.0.1
   args: ^2.0.0
@@ -25,7 +25,7 @@ dependencies:
   http: ^1.1.0
   meta: ^1.7.0
   path: ^1.8.0
-  platform: ^3.1.0 # overridden for lowest versions compatibility
+  platform: ^3.1.0
   pub_updater: ">=0.3.0 <0.6.0"
   source_span: ^1.9.0
   uuid: ^4.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_code_linter
-version: 3.2.0
+version: 3.2.0-alpha.1
 description: Dart Code Linter is a software analytics tool that helps developers analyse and improve software quality. Dart Code Linter is based on a fork of Dart Code Metrics.
 repository: https://github.com/bancolombia/dart-code-linter
 issue_tracker: https://github.com/bancolombia/dart-code-linter/issues

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -1,9 +1,9 @@
 name: dart_code_linter_analyzer_plugin_loader
 description: This pubspec determines the version of the analyzer plugin to load.
-version: 3.2.0
+version: 3.2.0-alpha.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  dart_code_linter: 3.2.0
+  dart_code_linter: 3.2.0-alpha.1


### PR DESCRIPTION
Resolve #198 

**Migration to new Dart analyzer API:**

* Replaced deprecated `staticElement` and related fields with `element`, and updated types such as `Element` to `Element2`, `ParameterElement` to `FormalParameterElement`, and `FunctionElement` to `TopLevelFunctionElement` across various visitors and rules. This affects files such as `always_remove_listener_rule.dart`, `arguments_ordering_rule.dart`, `avoid_dynamic/visitor.dart`, `avoid_global_state/visitor.dart`, `avoid_ignoring_return_values/visitor.dart`, `avoid_late_keyword/visitor.dart`, `avoid_missing_enum_constant_in_map/visitor.dart`, `avoid_returning_widgets/visitor.dart`, `avoid_unused_parameters/visitor.dart`, `ban_name/visitor.dart`, `check_for_equals_in_render_object_setters/visitor.dart`, `list_all_equatable_fields/visitor.dart`, and `prefer_enums_by_name/visitor.dart`. [[1]](diffhunk://#diff-594daf9d0c4e553e7de1ebe249e08914c5ddddc716294b635514e643cdf436f8L5-R5) [[2]](diffhunk://#diff-4169939f30c5827abd931f6d0b53ecb7ad42bcab2ee62c94a9f53575514ff34bR6) [[3]](diffhunk://#diff-58b961f30effff115f3f8d070c7bc8c8b64ab707059705dc72a03e114770d49fL22-R40) [[4]](diffhunk://#diff-58b961f30effff115f3f8d070c7bc8c8b64ab707059705dc72a03e114770d49fL89-R89) [[5]](diffhunk://#diff-bd05b6b4d12967646cf3a26ff03861d0a5b1e9d5e1aa93463c92c1dd88e750f0L29-R29) [[6]](diffhunk://#diff-01804bd18c21d24ab6fc79fee115907606ba24a2fd556e3f86347f8400b1a8f6L12-R26) [[7]](diffhunk://#diff-ba5a824885cd984fc8a384cdc9afe9e64502f93f5c8fdd8be7e1552d191b583fL28-R28) [[8]](diffhunk://#diff-98ae886f22889bc1be828e231133b6e43b522c9b82288b455aec536aa45f03ccL31-R31) [[9]](diffhunk://#diff-4edca28b6b4407c0640349407751b3df1a9009e5c30c6b64a4fb082bb7175faaL23-R25) [[10]](diffhunk://#diff-95cdaf448e4d2329fc3f2bdccbd36cd224f36640f3d8b8009a276087fa4bb92cL56-R56) [[11]](diffhunk://#diff-95cdaf448e4d2329fc3f2bdccbd36cd224f36640f3d8b8009a276087fa4bb92cL91-R91) [[12]](diffhunk://#diff-46ec780f574755728b8c337fb5a5cdad0ffe4c1aa9f92fd3660fca0750920f4aL66-R67) [[13]](diffhunk://#diff-46ec780f574755728b8c337fb5a5cdad0ffe4c1aa9f92fd3660fca0750920f4aL98-R99) [[14]](diffhunk://#diff-46ec780f574755728b8c337fb5a5cdad0ffe4c1aa9f92fd3660fca0750920f4aL115-R116) [[15]](diffhunk://#diff-2a8c5da0bd365ca064cdebd4b4086632f7ccc083e5ae27c7eec4a5722c01bc19L34-R34) [[16]](diffhunk://#diff-b053d81677afe9280b2201ac044b02ef2af011985f8b51966b4713e6531ca9c5L85-R85) [[17]](diffhunk://#diff-7a67faf2acfd6ec7e72deddde29488ecc6ba0a0b58a59fedeef5d415d8ae1f79L63) [[18]](diffhunk://#diff-7a67faf2acfd6ec7e72deddde29488ecc6ba0a0b58a59fedeef5d415d8ae1f79L77-R76) [[19]](diffhunk://#diff-7a67faf2acfd6ec7e72deddde29488ecc6ba0a0b58a59fedeef5d415d8ae1f79L87-R91) [[20]](diffhunk://#diff-d244e92fc61fa718f8cfaf154af14daabcb748a7ddc73fa3a13bb11ab3b82702L23-R23)

* Updated method and property names to match the new API, such as using `declaredFragment` and `element` instead of `declaredElement`, and updating how types and names are accessed on AST nodes. [[1]](diffhunk://#diff-95cdaf448e4d2329fc3f2bdccbd36cd224f36640f3d8b8009a276087fa4bb92cL56-R56) [[2]](diffhunk://#diff-2a8c5da0bd365ca064cdebd4b4086632f7ccc083e5ae27c7eec4a5722c01bc19L34-R34) [[3]](diffhunk://#diff-95cdaf448e4d2329fc3f2bdccbd36cd224f36640f3d8b8009a276087fa4bb92cL91-R91) [[4]](diffhunk://#diff-46ec780f574755728b8c337fb5a5cdad0ffe4c1aa9f92fd3660fca0750920f4aL66-R67) [[5]](diffhunk://#diff-46ec780f574755728b8c337fb5a5cdad0ffe4c1aa9f92fd3660fca0750920f4aL98-R99) [[6]](diffhunk://#diff-46ec780f574755728b8c337fb5a5cdad0ffe4c1aa9f92fd3660fca0750920f4aL115-R116) [[7]](diffhunk://#diff-7a67faf2acfd6ec7e72deddde29488ecc6ba0a0b58a59fedeef5d415d8ae1f79L77-R76)

**Modernization of type checks and string representations:**

* Updated type comparison and stringification to use the new `getDisplayString()` method without the deprecated `withNullability` parameter, and improved type checks for enums and mixins. [[1]](diffhunk://#diff-7a67faf2acfd6ec7e72deddde29488ecc6ba0a0b58a59fedeef5d415d8ae1f79L87-R91) [[2]](diffhunk://#diff-98ae886f22889bc1be828e231133b6e43b522c9b82288b455aec536aa45f03ccL31-R31) [[3]](diffhunk://#diff-d244e92fc61fa718f8cfaf154af14daabcb748a7ddc73fa3a13bb11ab3b82702L23-R23)

**Bug fixes and code simplification:**

* Removed unnecessary null assertion operators and deprecated member usage, and simplified code logic in several places, such as threshold checks and field name extraction. [[1]](diffhunk://#diff-06cd6a419afb6405e87573beb8bda94d022f05b3ff4e7309790b2ec1ceca8d94L56-R56) [[2]](diffhunk://#diff-5e46523871922eff2041018f34453b6842e7a353cfedc9c5821d6b5cbeee630aL53-R53) [[3]](diffhunk://#diff-7a67faf2acfd6ec7e72deddde29488ecc6ba0a0b58a59fedeef5d415d8ae1f79L77-R76)

**Dependency update:**

* Added `dart_style: 3.1.2` to the `example/pubspec.yaml` dependencies.