### PR TITLE
chore: update analyzer constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.2.0-alpha.2
+- Update `analyzer` constraint to ^8.2.0
+
 ## 3.2.0-alpha.1
 - Add rule `use-design-system-items`.
 - Add rule `only-barrel-import`.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -154,7 +154,6 @@ linter:
     - omit_local_variable_types
     #    - one_member_abstracts
     - only_throw_errors
-    - package_api_docs
     - parameter_assignments
     - prefer_asserts_in_initializer_lists
     - prefer_asserts_with_message

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/use_design_system/use_design_system_item_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/use_design_system/use_design_system_item_rule.dart
@@ -4,13 +4,13 @@ import '../../../../../../lint_analyzer.dart';
 import '../../../../../utils/node_utils.dart';
 import '../../../lint_utils.dart';
 import '../../../models/internal_resolved_unit_result.dart';
-import '../../models/dart_rule.dart';
+import '../../models/flutter_rule.dart';
 import '../../rule_utils.dart';
 
 part 'visitor.dart';
 part 'config_parser.dart';
 
-class UseDesignSystemItemRule extends DartRule {
+class UseDesignSystemItemRule extends FlutterRule {
   static const String ruleId = 'use-design-system-item';
 
   final Map<String, _ReplacementSuggestion> _configurations;

--- a/lib/src/analyzers/unnecessary_nullable_analyzer/unnecessary_nullable_analyzer.dart
+++ b/lib/src/analyzers/unnecessary_nullable_analyzer/unnecessary_nullable_analyzer.dart
@@ -298,9 +298,9 @@ class UnnecessaryNullableAnalyzer {
   ) {
     final libraryFragment = element.firstFragment.libraryFragment;
 
-    final offset = element.firstFragment.codeOffset;
+    final offset = element.firstFragment.codeOffset!;
     final lineInfo = libraryFragment?.lineInfo;
-    final offsetLocation = lineInfo?.getLocation(offset!);
+    final offsetLocation = lineInfo?.getLocation(offset);
 
     final sourceUrl = libraryFragment?.source.uri;
 
@@ -309,7 +309,7 @@ class UnnecessaryNullableAnalyzer {
       declarationType: element.kind.displayName,
       parameters: parameters.map((parameter) => parameter.toString()),
       location: SourceLocation(
-        offset!,
+        offset,
         sourceUrl: sourceUrl,
         line: offsetLocation?.lineNumber,
         column: offsetLocation?.columnNumber,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ platforms:
   macos:
 
 dependencies:
-  analyzer: ^8.0.0
+  analyzer: ^8.2.0
   analyzer_plugin: ^0.13.0
   ansicolor: ^2.0.1
   args: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_code_linter
-version: 3.2.0-alpha.1
+version: 3.2.0-alpha.2
 description: Dart Code Linter is a software analytics tool that helps developers analyse and improve software quality. Dart Code Linter is based on a fork of Dart Code Metrics.
 repository: https://github.com/bancolombia/dart-code-linter
 issue_tracker: https://github.com/bancolombia/dart-code-linter/issues

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -1,9 +1,9 @@
 name: dart_code_linter_analyzer_plugin_loader
 description: This pubspec determines the version of the analyzer plugin to load.
-version: 3.2.0-alpha.1
+version: 3.2.0-alpha.2
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  dart_code_linter: 3.2.0-alpha.1
+  dart_code_linter: 3.2.0-alpha.2


### PR DESCRIPTION

**Dependency upgrades:**

* Updated the `analyzer` dependency in `pubspec.yaml` from version `^8.0.0` to `^8.2.0` to ensure compatibility with newer features and bug fixes.

**Lint rule refactoring:**

* Changed the base class of `UseDesignSystemItemRule` from `DartRule` to `FlutterRule` in `use_design_system_item_rule.dart`, and updated the corresponding import to use `flutter_rule.dart` instead of `dart_rule.dart`. This aligns the rule implementation with Flutter-specific analysis.


**Linter configuration update:**

* Removed the `package_api_docs` linter rule from `analysis_options.yaml` to adjust the active lint rules and streamline code analysis.