### PR TITLE
ci: update versions and add Pana score review

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,3 +20,32 @@ jobs:
         run: dart pub get
       - name: Run tests
         run: dart test
+  
+  pana:
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Flutter
+        uses: bancolombia/flutter-setup-action@v1.1
+        with:
+          channel: 'stable'
+          flutter-version: '3.35.0'
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y webp
+          dart pub get
+          dart pub global activate pana
+
+      - name: Verify Pub Score
+        run: |
+          dart --version
+          flutter --version
+          PANA=$(pana . --no-warning); PANA_SCORE=$(echo $PANA | sed -n "s/.*Points: \([0-9]*\)\/\([0-9]*\)./\1\/\2/p")
+          echo "score: $PANA_SCORE"
+          IFS='/'; read -a SCORE_ARR <<< "$PANA_SCORE"; SCORE=SCORE_ARR[0]; TOTAL=SCORE_ARR[1]
+          if (( $SCORE < $TOTAL - 10 )); then echo $PANA; echo "minimum score not met!"; exit 1; fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
-      - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v3
+      - name: Setup Flutter
+        uses: bancolombia/flutter-setup-action@v1.1
         with:
-          channel: stable
-          version: 3.32.0
+          channel: 'stable'
+          flutter-version: '3.35.0'
       - name: Install dependencies
         run: dart pub get
       - name: Publish to pub.dev


### PR DESCRIPTION
**CI Workflow Improvements:**

* Added a new `pana` job to `.github/workflows/build.yaml` that installs dependencies, activates `pana`, and verifies the package's pub score, failing the build if the score does not meet the minimum threshold.

**Flutter Setup Standardization:**

* Replaced the previous Flutter setup action in `.github/workflows/release.yaml` with `bancolombia/flutter-setup-action@v1.1`, updating the Flutter channel to `'stable'` and the version to `'3.35.0'` for consistency and reliability.
* Applied the same `bancolombia/flutter-setup-action@v1.1` for Flutter setup in the new `pana` job in `.github/workflows/build.yaml`, ensuring both workflows use the same Flutter version and setup method.