### PR TITLE
feat: migrate DCL analyzer integration to analysis_server_plugin (Dart ≥ 3.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,37 @@ dart pub add --dev dart_code_linter
 
 ## Basic configuration
 
-Add configuration to `analysis_options.yaml` and reload IDE to allow the analyzer to discover the plugin config.
+Add configuration to `analysis_options.yaml` and reload your IDE to allow the analyzer to discover the plugin.
 
+### Dart ≥ 3.9 (recommended)
 
-### Basic config example
+Use the new top-level `plugins:` key introduced in Dart 3.9 / `analysis_server_plugin`:
+
+```yaml title="analysis_options.yaml"
+plugins:
+  dart_code_linter:
+    diagnostics:
+      avoid-dynamic: true
+      avoid-passing-async-when-sync-expected: true
+      avoid-redundant-async: true
+      avoid-unnecessary-type-assertions: true
+      avoid-unnecessary-type-casts: true
+      avoid-unrelated-type-assertions: true
+      avoid-unused-parameters: true
+      avoid-nested-conditional-expressions: true
+      newline-before-return: true
+      no-boolean-literal-compare: true
+      no-empty-block: true
+      prefer-trailing-comma: true
+      prefer-conditional-expressions: true
+      no-equal-then-else: true
+      prefer-moving-to-variable: true
+      prefer-match-file-name: true
+```
+
+### Dart < 3.9 (legacy)
+
+For projects using an older Dart SDK, use the `analyzer.plugins` configuration:
 
 ```yaml title="analysis_options.yaml"
 analyzer:
@@ -50,11 +77,9 @@ dart_code_linter:
 
 ### Basic config with metrics
 
-```yaml title="analysis_options.yaml"
-analyzer:
-  plugins:
-    - dart_code_linter
+Metrics are available via the CLI and are configured using the legacy `dart_code_linter:` section regardless of which plugin integration you use:
 
+```yaml title="analysis_options.yaml"
 dart_code_linter:
   metrics:
     cyclomatic-complexity: 20
@@ -62,23 +87,6 @@ dart_code_linter:
     maximum-nesting-level: 5
   metrics-exclude:
     - test/**
-  rules:
-    - avoid-dynamic
-    - avoid-passing-async-when-sync-expected
-    - avoid-redundant-async
-    - avoid-unnecessary-type-assertions
-    - avoid-unnecessary-type-casts
-    - avoid-unrelated-type-assertions
-    - avoid-unused-parameters
-    - avoid-nested-conditional-expressions
-    - newline-before-return
-    - no-boolean-literal-compare
-    - no-empty-block
-    - prefer-trailing-comma
-    - prefer-conditional-expressions
-    - no-equal-then-else
-    - prefer-moving-to-variable
-    - prefer-match-file-name
 ```
 
 ## Usage

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,17 @@
+import 'src/analysis_server_plugin/dart_code_linter_plugin.dart';
+
+/// The top-level `plugin` variable required by the Dart Analysis Server's
+/// new plugin protocol (Dart ≥ 3.9 / `analysis_server_plugin`).
+///
+/// The analysis server discovers this plugin via the `plugins:` key in
+/// `analysis_options.yaml`:
+///
+/// ```yaml
+/// plugins:
+///   dart_code_linter:
+///     diagnostics:
+///       avoid-dynamic: true
+///       prefer-trailing-comma: true
+/// ```
+// ignore: public_member_api_docs
+final plugin = DartCodeLinterPlugin();

--- a/lib/src/analysis_server_plugin/dart_code_linter_plugin.dart
+++ b/lib/src/analysis_server_plugin/dart_code_linter_plugin.dart
@@ -1,0 +1,61 @@
+import 'package:analysis_server_plugin/plugin.dart';
+import 'package:analysis_server_plugin/registry.dart';
+
+import '../analyzers/lint_analyzer/rules/models/rule.dart';
+import '../analyzers/lint_analyzer/rules/rules_factory.dart';
+import 'dcl_analysis_rule.dart';
+
+/// The `analysis_server_plugin` entry-point for Dart Code Linter.
+///
+/// This plugin registers all DCL lint rules with the [PluginRegistry] so they
+/// are picked up by the Dart Analysis Server (Dart ≥ 3.9). Rules that require
+/// mandatory user configuration (e.g. `avoid-banned-imports`, `ban-name`) are
+/// skipped here; they can still be used via the legacy `analyzer.plugins`
+/// mechanism or future per-rule configuration support.
+///
+/// **Usage in `analysis_options.yaml`:**
+/// ```yaml
+/// plugins:
+///   dart_code_linter:
+///     diagnostics:
+///       avoid-dynamic: true
+///       prefer-trailing-comma: true
+///       # … add any DCL rule ID to enable it
+/// ```
+final class DartCodeLinterPlugin extends Plugin {
+  @override
+  String get name => 'dart_code_linter';
+
+  @override
+  void register(PluginRegistry registry) {
+    for (final id in allRuleIds) {
+      final rule = _tryCreateRule(id);
+      if (rule != null) {
+        registry.registerLintRule(DclAnalysisRule(rule));
+      }
+    }
+  }
+}
+
+/// Attempts to instantiate a DCL [Rule] with an empty configuration map.
+///
+/// Rules marked with [Rule.requiresConfig] need mandatory user-supplied
+/// configuration values and cannot be instantiated with an empty map, so they
+/// are skipped (returns `null`).
+Rule? _tryCreateRule(String id) {
+  // getRulesById only includes IDs present in the config map, so we call it
+  // with a single-entry map to get one rule at a time with an empty config.
+  try {
+    final rules = getRulesById({id: {}});
+    final rule = rules.firstOrNull;
+    if (rule == null || rule.requiresConfig) {
+      return null;
+    }
+
+    return rule;
+  } on Exception catch (_) {
+    // If instantiation fails (e.g. the rule validates its config eagerly),
+    // skip it gracefully so other rules still load.
+    return null;
+  }
+}

--- a/lib/src/analysis_server_plugin/dcl_analysis_rule.dart
+++ b/lib/src/analysis_server_plugin/dcl_analysis_rule.dart
@@ -1,0 +1,75 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
+
+import '../analyzers/lint_analyzer/models/internal_resolved_unit_result.dart';
+import '../analyzers/lint_analyzer/rules/models/rule.dart';
+
+/// Bridges a DCL [Rule] into the new [AnalysisRule] interface required by
+/// `analysis_server_plugin` (Dart ≥ 3.9 / Dart Analysis Server plugin API).
+///
+/// Each DCL rule is wrapped in one [DclAnalysisRule]. The wrapper visits every
+/// [CompilationUnit], delegates analysis to the underlying DCL rule via
+/// `Rule.check`, and reports the returned issues using [reportAtOffset].
+///
+/// The [LintCode.problemMessage] uses the `{0}` placeholder so that the
+/// per-issue message from DCL is forwarded verbatim to the IDE/CLI.
+/// The optional [LintCode.correctionMessage] uses `{1}` for the verbose message.
+final class DclAnalysisRule extends AnalysisRule {
+  final Rule _dclRule;
+
+  /// The [LintCode] is created lazily and cached so it is only allocated once
+  /// per rule instance.
+  late final LintCode _lintCode = LintCode(
+    _dclRule.id,
+    '{0}',
+    correctionMessage: '{1}',
+  );
+
+  DclAnalysisRule(this._dclRule)
+    : super(name: _dclRule.id, description: _dclRule.id);
+
+  @override
+  DiagnosticCode get diagnosticCode => _lintCode;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addCompilationUnit(this, _DclVisitor(this, context));
+  }
+}
+
+class _DclVisitor extends SimpleAstVisitor<void> {
+  final DclAnalysisRule _rule;
+  final RuleContext _context;
+
+  _DclVisitor(this._rule, this._context);
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    final contextUnit = _context.currentUnit;
+    if (contextUnit == null) {
+      return;
+    }
+
+    final source = InternalResolvedUnitResult(
+      contextUnit.file.path,
+      contextUnit.content,
+      node,
+      node.lineInfo,
+    );
+
+    for (final issue in _rule._dclRule.check(source)) {
+      _rule.reportAtOffset(
+        issue.location.start.offset,
+        issue.location.length,
+        arguments: [issue.message, issue.verboseMessage ?? ''],
+      );
+    }
+  }
+}

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/arguments_ordering/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/arguments_ordering/visitor.dart
@@ -40,18 +40,18 @@ class _Visitor extends RecursiveAstVisitor<void> {
     List<FormalParameterElement> parameters,
   ) {
     final sortedArguments = argumentList.arguments.sorted((a, b) {
-      if (a is! NamedExpression && b is! NamedExpression) {
+      if (a is! NamedArgument && b is! NamedArgument) {
         return 0;
       }
-      if (a is NamedExpression && b is! NamedExpression) {
+      if (a is NamedArgument && b is! NamedArgument) {
         return 1;
       }
-      if (a is! NamedExpression && b is NamedExpression) {
+      if (a is! NamedArgument && b is NamedArgument) {
         return -1;
       }
-      if (a is NamedExpression && b is NamedExpression) {
-        final aName = a.name.label.name;
-        final bName = b.name.label.name;
+      if (a is NamedArgument && b is NamedArgument) {
+        final aName = a.name.lexeme;
+        final bName = b.name.lexeme;
 
         if (aName == bName) {
           return 0;
@@ -87,10 +87,10 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   static int _parameterIndex(
     List<FormalParameterElement> parameters,
-    NamedExpression argumentExpression,
+    NamedArgument argumentExpression,
   ) =>
       parameters.indexWhere(
-        (parameter) => parameter.name == argumentExpression.name.label.name,
+        (parameter) => parameter.name == argumentExpression.name.lexeme,
       );
 }
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_border_all/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_border_all/visitor.dart
@@ -17,7 +17,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
       var isAllConst = true;
 
       for (final argument in expression.argumentList.arguments) {
-        final arg = (argument as NamedExpression).expression;
+        final arg = (argument as NamedArgument).argumentExpression;
         if (arg is Literal) {
           continue;
         } else if (arg is MethodInvocation ||

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_collection_methods_with_unrelated_types/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_collection_methods_with_unrelated_types/visitor.dart
@@ -30,7 +30,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
     final listType = _getListTypeElement(staticType);
     final setType = _getSetTypeElement(staticType);
     final iterableType = _getIterableTypeElement(staticType);
-    final argType = node.argumentList.arguments.singleOrNull?.staticType;
+    final argType =
+        node.argumentList.arguments.singleOrNull?.argumentExpression.staticType;
 
     switch (node.methodName.name) {
       case 'containsKey':

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_expanded_as_spacer/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_expanded_as_spacer/visitor.dart
@@ -20,11 +20,9 @@ class _Visitor extends RecursiveAstVisitor<void> {
     final hasOneArgument = arguments.length == 1;
 
     if (isExpanded && hasOneArgument) {
-      final expandedChild = arguments.first as NamedExpression;
-
-      final childName = expandedChild.staticType?.getDisplayString();
-
-      final child = expandedChild.expression;
+      final expandedChild = arguments.first as NamedArgument;
+      final child = expandedChild.argumentExpression;
+      final childName = child.staticType?.getDisplayString();
       if (child is InstanceCreationExpression) {
         final hasNoArgument = child.argumentList.arguments.isEmpty;
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/visitor.dart
@@ -1,9 +1,9 @@
 part of 'avoid_passing_async_when_sync_expected_rule.dart';
 
 class _Visitor extends RecursiveAstVisitor<void> {
-  final _invalidArguments = <Expression>[];
+  final _invalidArguments = <Argument>[];
 
-  Iterable<Expression> get invalidArguments => _invalidArguments;
+  Iterable<Argument> get invalidArguments => _invalidArguments;
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
@@ -25,7 +25,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   void _handleInvalidArguments(ArgumentList arguments) {
     for (final argument in arguments.arguments) {
-      final argumentType = argument.staticType;
+      final argumentExpression = argument.argumentExpression;
+      final argumentType = argumentExpression.staticType;
       final parameterType = argument.correspondingParameter?.type;
       if (argumentType is FunctionType && parameterType is FunctionType) {
         if (argumentType.returnType.isDartAsyncFuture &&

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/visitor.dart
@@ -87,13 +87,13 @@ class _InvocationsVisitor extends RecursiveAstVisitor<void> {
   bool _isInsideBuilder(MethodInvocation node) {
     final grandParent = node.parent?.parent;
     if (grandParent is FunctionExpression &&
-        grandParent.parent is! NamedExpression) {
+        grandParent.parent is! NamedArgument) {
       return grandParent.declaredFragment?.enclosingFragment?.name == 'build';
     }
 
-    final expression = node.thisOrAncestorOfType<NamedExpression>();
-    if (expression is NamedExpression) {
-      final type = expression.staticType;
+    final expression = node.thisOrAncestorOfType<NamedArgument>();
+    if (expression is NamedArgument) {
+      final type = expression.argumentExpression.staticType;
       if (type is FunctionType) {
         return type.returnType is InterfaceType &&
             _hasWidgetType(type.returnType, _allowNullable);

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_shrink_wrap_in_lists/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_shrink_wrap_in_lists/visitor.dart
@@ -18,7 +18,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   bool _hasShrinkWrap(InstanceCreationExpression node) =>
       node.argumentList.arguments.firstWhereOrNull(
-        (arg) => arg is NamedExpression && arg.name.label.name == 'shrinkWrap',
+        (arg) => arg is NamedArgument && arg.name.lexeme == 'shrinkWrap',
       ) !=
       null;
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_wrapping_in_padding/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_wrapping_in_padding/visitor.dart
@@ -16,11 +16,11 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   bool _hasChildWithPadding(InstanceCreationExpression node) {
     final child = node.argumentList.arguments.firstWhereOrNull(
-      (arg) => arg is NamedExpression && arg.name.label.name == 'child',
+      (arg) => arg is NamedArgument && arg.name.lexeme == 'child',
     );
 
-    if (child != null && child is NamedExpression) {
-      final expression = child.expression;
+    if (child != null && child is NamedArgument) {
+      final expression = child.argumentExpression;
 
       return expression is InstanceCreationExpression &&
           expression.staticType?.getDisplayString() == 'Container';

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/consistent_update_render_object/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/consistent_update_render_object/visitor.dart
@@ -53,11 +53,10 @@ class _Visitor extends GeneralizingAstVisitor<void> {
     }
   }
 
-  int _getCountableArgumentsLength(List<Expression> arguments) =>
+  int _getCountableArgumentsLength(List<Argument> arguments) =>
       arguments.where(
         (argument) {
-          final expression =
-              argument is NamedExpression ? argument.expression : argument;
+          final expression = argument.argumentExpression;
 
           return expression is! NullLiteral &&
               !isRenderObjectElementOrSubclass(expression.staticType);
@@ -82,7 +81,7 @@ class _MethodsVisitor extends GeneralizingAstVisitor<void> {
 }
 
 class _CreationVisitor extends RecursiveAstVisitor<void> {
-  final arguments = <Expression>[];
+  final arguments = <Argument>[];
 
   @override
   void visitReturnStatement(ReturnStatement node) {

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/correct_game_instantiating/correct_game_instantiating_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/correct_game_instantiating/correct_game_instantiating_rule.dart
@@ -50,8 +50,8 @@ class CorrectGameInstantiatingRule extends FlameRule {
   List<Replacement>? _createReplacement(_InstantiationInfo info) {
     if (info.isStateless) {
       final arguments = info.node.argumentList.arguments.map((arg) {
-        if (arg is NamedExpression && arg.name.label.name == 'game') {
-          final expression = arg.expression;
+        if (arg is NamedArgument && arg.name.lexeme == 'game') {
+          final expression = arg.argumentExpression;
           if (expression is InstanceCreationExpression) {
             final name = expression.staticType?.getDisplayString();
             if (name != null) {

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/correct_game_instantiating/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/correct_game_instantiating/visitor.dart
@@ -55,11 +55,11 @@ class _GameWidgetInstantiatingVisitor extends RecursiveAstVisitor<void> {
         node.constructorName.name?.name != 'controlled') {
       final gameArgument = node.argumentList.arguments.firstWhereOrNull(
         (argument) =>
-            argument is NamedExpression && argument.name.label.name == 'game',
+            argument is NamedArgument && argument.name.lexeme == 'game',
       );
 
-      if (gameArgument is NamedExpression &&
-          gameArgument.expression is InstanceCreationExpression) {
+      if (gameArgument is NamedArgument &&
+          gameArgument.argumentExpression is InstanceCreationExpression) {
         wrongInstantiation = node;
       }
     }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/visitor.dart
@@ -1,12 +1,12 @@
 part of 'no_equal_arguments_rule.dart';
 
 class _Visitor extends RecursiveAstVisitor<void> {
-  final _arguments = <Expression>[];
+  final _arguments = <Argument>[];
 
   final Iterable<String> _ignoredParameters;
   final Iterable<String> _ignoredArguments;
 
-  Iterable<Expression> get arguments => _arguments;
+  Iterable<Argument> get arguments => _arguments;
 
   _Visitor(this._ignoredParameters, this._ignoredArguments);
 
@@ -31,25 +31,28 @@ class _Visitor extends RecursiveAstVisitor<void> {
     _visitArguments(node.argumentList.arguments);
   }
 
-  void _visitArguments(Iterable<Expression> arguments) {
+  void _visitArguments(Iterable<Argument> arguments) {
     final notIgnoredArguments = arguments.whereNot(_isIgnored).toList();
 
     for (final argument in notIgnoredArguments) {
+      final argumentExpression = argument.argumentExpression;
       final lastAppearance = notIgnoredArguments.lastWhere((arg) {
-        if (argument is NamedExpression &&
-            arg is NamedExpression &&
-            argument.expression is! Literal &&
-            arg.expression is! Literal) {
-          return haveSameParameterType(argument.expression, arg.expression) &&
-              argument.expression.toString() == arg.expression.toString();
+        final argExpression = arg.argumentExpression;
+
+        if (argument is NamedArgument &&
+            arg is NamedArgument &&
+            argumentExpression is! Literal &&
+            argExpression is! Literal) {
+          return haveSameParameterType(argumentExpression, argExpression) &&
+              argumentExpression.toString() == argExpression.toString();
         }
 
-        if (_bothLiterals(argument, arg)) {
-          return argument == arg;
+        if (_bothLiterals(argumentExpression, argExpression)) {
+          return argumentExpression == argExpression;
         }
 
-        return haveSameParameterType(argument, arg) &&
-            argument.toString() == arg.toString();
+        return haveSameParameterType(argumentExpression, argExpression) &&
+            argumentExpression.toString() == argExpression.toString();
       });
 
       if (argument != lastAppearance) {
@@ -65,15 +68,18 @@ class _Visitor extends RecursiveAstVisitor<void> {
           right is PrefixExpression &&
           right.operand is Literal);
 
-  bool _isIgnored(Expression arg) {
-    if (arg is NamedExpression) {
-      final expression = arg.expression;
+  bool _isIgnored(Argument arg) {
+    if (arg is NamedArgument) {
+      final expression = arg.argumentExpression;
 
-      return _ignoredParameters.contains(arg.name.label.name) ||
+      return _ignoredParameters.contains(arg.name.lexeme) ||
           (expression is SimpleIdentifier &&
               _ignoredArguments.contains(expression.name));
     }
 
-    return arg is SimpleIdentifier && _ignoredArguments.contains(arg.name);
+    final expression = arg.argumentExpression;
+
+    return expression is SimpleIdentifier &&
+        _ignoredArguments.contains(expression.name);
   }
 }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_define_hero_tag/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_define_hero_tag/visitor.dart
@@ -26,8 +26,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
                 methodName == _constructorLargeName ||
                 methodName == _constructorSmallName)) {
       if (!node.argumentList.arguments.any((arg) =>
-          arg is NamedExpression &&
-          arg.name.label.name == _heroTagPropertyName)) {
+          arg is NamedArgument && arg.name.lexeme == _heroTagPropertyName)) {
         _invocations.add(node);
       }
     }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
@@ -1,13 +1,13 @@
 part of 'prefer_extracting_callbacks_rule.dart';
 
 class _Visitor extends SimpleAstVisitor<void> {
-  final _expressions = <Expression>[];
+  final _expressions = <Argument>[];
 
   final LineInfo _lineInfo;
   final Iterable<String> _ignoredArguments;
   final int? _allowedLineCount;
 
-  Iterable<Expression> get expressions => _expressions;
+  Iterable<Argument> get expressions => _expressions;
 
   _Visitor(this._lineInfo, this._ignoredArguments, this._allowedLineCount);
 
@@ -30,13 +30,13 @@ class _Visitor extends SimpleAstVisitor<void> {
 }
 
 class _InstanceCreationVisitor extends RecursiveAstVisitor<void> {
-  final _expressions = <Expression>[];
+  final _expressions = <Argument>[];
 
   final LineInfo _lineInfo;
   final Iterable<String> _ignoredArguments;
   final int? _allowedLineCount;
 
-  Iterable<Expression> get expressions => _expressions;
+  Iterable<Argument> get expressions => _expressions;
 
   _InstanceCreationVisitor(
     this._lineInfo,
@@ -49,8 +49,7 @@ class _InstanceCreationVisitor extends RecursiveAstVisitor<void> {
     super.visitInstanceCreationExpression(node);
 
     for (final argument in node.argumentList.arguments) {
-      final expression =
-          argument is NamedExpression ? argument.expression : argument;
+      final expression = argument.argumentExpression;
 
       if (_isNotIgnored(argument) &&
           expression is FunctionExpression &&
@@ -87,9 +86,9 @@ class _InstanceCreationVisitor extends RecursiveAstVisitor<void> {
             );
   }
 
-  bool _isNotIgnored(Expression argument) =>
-      argument is! NamedExpression ||
-      !_ignoredArguments.contains(argument.name.label.name);
+  bool _isNotIgnored(Argument argument) =>
+      argument is! NamedArgument ||
+      !_ignoredArguments.contains(argument.name.lexeme);
 
   bool _isLongEnough(Expression expression) {
     final allowedLineCount = _allowedLineCount;

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_intl_name/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_intl_name/visitor.dart
@@ -9,10 +9,10 @@ class _Visitor extends IntlBaseVisitor {
     FormalParameterList? parameterList,
   }) {
     final nameExpression = methodInvocation.argumentList.arguments
-        .whereType<NamedExpression>()
-        .where((argument) => argument.name.label.name == 'name')
+        .whereType<NamedArgument>()
+        .where((argument) => argument.name.lexeme == 'name')
         .firstOrNull
-        ?.expression
+        ?.argumentExpression
         .as<SimpleStringLiteral>();
 
     if (nameExpression == null) {

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_iterable_of/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_iterable_of/visitor.dart
@@ -14,7 +14,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
         _hasConstructorOf(node.staticType)) {
       final arg = node.argumentList.arguments.first;
 
-      final argumentType = _getType(arg.staticType);
+      final argumentType = _getType(arg.argumentExpression.staticType);
       final castedType = _getType(node.staticType);
       if (argumentType != null &&
           !argumentType.isDartCoreObject &&

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
@@ -209,8 +209,7 @@ class _BlockVisitor extends RecursiveAstVisitor<void> {
       visitedInvocation is MethodInvocation &&
       node is MethodInvocation &&
       visitedInvocation.argumentList.arguments.any((argument) {
-        final expression =
-            argument is NamedExpression ? argument.expression : argument;
+        final expression = argument.argumentExpression;
 
         if (expression is SimpleIdentifier) {
           final element = expression.element;

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/prefer_named_record_fields_rule.dart
@@ -90,7 +90,7 @@ class PreferNamedRecordFieldsRule extends DartRule {
     RecordLiteral recordLiteral,
   ) {
     final positionalFields = recordLiteral.fields
-        .where((field) => field is! NamedExpression)
+        .where((field) => field is! NamedArgument)
         .toList();
 
     if (positionalFields.isEmpty) {
@@ -111,7 +111,7 @@ class PreferNamedRecordFieldsRule extends DartRule {
 
     final namedFieldsStr = namedFields.join(', ');
     final existingNamed = recordLiteral.fields
-        .whereType<NamedExpression>()
+        .whereType<NamedArgument>()
         .map((field) => field.toSource())
         .join(', ');
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_named_record_fields/visitor.dart
@@ -39,7 +39,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
     var namedCount = 0;
 
     for (final field in recordLiteral.fields) {
-      if (field is NamedExpression) {
+      if (field is NamedArgument) {
         namedCount++;
       } else {
         positionalCount++;

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_provide_intl_description/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_provide_intl_description/visitor.dart
@@ -23,10 +23,12 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   bool _withEmptyDescription(ArgumentList args) =>
       args.arguments.any((argument) =>
-          argument is NamedExpression &&
-          argument.name.label.name == 'desc' &&
-          argument.expression is SimpleStringLiteral &&
-          (argument.expression as SimpleStringLiteral).value.isEmpty) ||
-      args.arguments.every((argument) =>
-          argument is! NamedExpression || argument.name.label.name != 'desc');
+          argument is NamedArgument &&
+          argument.name.lexeme == 'desc' &&
+          argument.argumentExpression is SimpleStringLiteral &&
+          (argument.argumentExpression as SimpleStringLiteral).value.isEmpty) ||
+      args.arguments.every(
+        (argument) =>
+            argument is! NamedArgument || argument.name.lexeme != 'desc',
+      );
 }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_using_list_view/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_using_list_view/visitor.dart
@@ -17,16 +17,16 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   bool _hasColumnChild(InstanceCreationExpression node) {
     final child = node.argumentList.arguments.firstWhereOrNull(
-      (arg) => arg is NamedExpression && arg.name.label.name == 'child',
+      (arg) => arg is NamedArgument && arg.name.lexeme == 'child',
     );
 
-    if (child != null && child is NamedExpression) {
-      final expression = child.expression;
+    if (child != null && child is NamedArgument) {
+      final expression = child.argumentExpression;
 
       if (expression is InstanceCreationExpression &&
           isColumnWidget(expression.staticType)) {
         final notChildren = expression.argumentList.arguments.firstWhereOrNull(
-          (arg) => arg is NamedExpression && arg.name.label.name != 'children',
+          (arg) => arg is NamedArgument && arg.name.lexeme != 'children',
         );
 
         return notChildren == null;

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/provide_correct_intl_args/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/provide_correct_intl_args/visitor.dart
@@ -25,10 +25,10 @@ class _Visitor extends IntlBaseVisitor {
   ) {
     final arguments = methodInvocation.argumentList.arguments;
     final argsArgument = arguments
-        .whereType<NamedExpression>()
-        .where((argument) => argument.name.label.name == 'args')
+        .whereType<NamedArgument>()
+        .where((argument) => argument.name.lexeme == 'args')
         .firstOrNull
-        ?.expression
+        ?.argumentExpression
         .as<ListLiteral>();
 
     final parameterSimpleIdentifiers =

--- a/lib/src/analyzers/unnecessary_nullable_analyzer/declarations_visitor.dart
+++ b/lib/src/analyzers/unnecessary_nullable_analyzer/declarations_visitor.dart
@@ -78,8 +78,7 @@ class DeclarationsVisitor extends RecursiveAstVisitor<void> {
                 (isNullableType(type) &&
                     (!parameter.isOptional ||
                         parameter.isOptional && parameter.isRequired)) ||
-            (parameter is DefaultFormalParameter &&
-                parameter.defaultValue == null);
+            parameter.defaultClause == null;
       });
 
   void _getDeclarationElement(

--- a/lib/src/analyzers/unnecessary_nullable_analyzer/unnecessary_nullable_analyzer.dart
+++ b/lib/src/analyzers/unnecessary_nullable_analyzer/unnecessary_nullable_analyzer.dart
@@ -221,10 +221,9 @@ class UnnecessaryNullableAnalyzer {
         parameters.where((parameter) => !parameter.isNamed).toList();
 
     for (final usage in usages) {
-      final namedArguments =
-          usage.arguments.whereType<NamedExpression>().toList();
+      final namedArguments = usage.arguments.whereType<NamedArgument>().toList();
       final notNamedArguments =
-          usage.arguments.whereNot((arg) => arg is NamedExpression).toList();
+          usage.arguments.whereNot((arg) => arg is NamedArgument).toList();
 
       for (final parameter in parameters) {
         final relatedArgument = _findRelatedArgument(
@@ -258,33 +257,30 @@ class UnnecessaryNullableAnalyzer {
     );
   }
 
-  Expression? _findRelatedArgument(
+  Argument? _findRelatedArgument(
     FormalParameter parameter,
-    List<Expression> namedArguments,
-    List<Expression> notNamedArguments,
+    List<NamedArgument> namedArguments,
+    List<Argument> notNamedArguments,
     List<FormalParameter> notNamedParameters,
   ) {
     if (parameter.isNamed) {
-      return namedArguments.firstWhereOrNull((arg) =>
-          arg is NamedExpression &&
-          arg.name.label.name == parameter.name?.lexeme);
+      return namedArguments.firstWhereOrNull(
+        (arg) => arg.name.lexeme == parameter.name?.lexeme,
+      );
     }
 
     final parameterIndex = notNamedParameters.indexOf(parameter);
 
-    return notNamedArguments
-        .whereNot((element) => element is NamedExpression)
-        .firstWhereIndexedOrNull((index, _) => index == parameterIndex);
+    return notNamedArguments.firstWhereIndexedOrNull(
+      (index, _) => index == parameterIndex,
+    );
   }
 
-  bool _shouldMarkParameterAsNullable(Expression argument) {
-    if (argument is NamedExpression) {
-      return _shouldMarkParameterAsNullable(argument.expression);
-    }
+  bool _shouldMarkParameterAsNullable(Argument argument) {
+    final expression = argument.argumentExpression;
+    final staticType = expression.staticType;
 
-    final staticType = argument.staticType;
-
-    final isNullable = argument is NullLiteral ||
+    final isNullable = expression is NullLiteral ||
         (staticType != null &&
             // ignore: deprecated_member_use
             (staticType is DynamicType || isNullableType(staticType)));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/bancolombia/dart-code-linter
 issue_tracker: https://github.com/bancolombia/dart-code-linter/issues
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 platforms:
   linux:
@@ -14,7 +14,8 @@ platforms:
   macos:
 
 dependencies:
-  analyzer: ">=10.0.0 <13.0.0"
+  analysis_server_plugin: ">=0.3.0 <1.0.0"
+  analyzer: ">=13.0.0 <14.0.0"
   analyzer_plugin: ">=0.14.0 <0.16.0"
   ansicolor: ^2.0.1
   args: ^2.0.0


### PR DESCRIPTION


## Summary

Adds support for the new `analysis_server_plugin` protocol introduced in Dart 3.9+, which replaces the legacy `analyzer.plugins` system.

## What changed

### New plugin infrastructure (`lib/`)
- **`lib/main.dart`** — top-level `plugin` variable required by the new plugin protocol
- **`lib/src/analysis_server_plugin/dart_code_linter_plugin.dart`** — `DartCodeLinterPlugin extends Plugin` that registers all DCL rules via `PluginRegistry.registerLintRule()`
- **`lib/src/analysis_server_plugin/dcl_analysis_rule.dart`** — `DclAnalysisRule` bridge that wraps each DCL `Rule` as an `AnalysisRule`, visiting each `CompilationUnit` and forwarding issues via `reportAtOffset()` with `LintCode` `{0}`/`{1}` message templates

### Dependency updates (`pubspec.yaml`)
- `sdk`: `>=3.5.0` → `>=3.9.0 <4.0.0`
- `analyzer`: `>=10.0.0 <13.0.0` → `>=13.0.0 <14.0.0`
- Added `analysis_server_plugin: ">=0.3.0 <1.0.0"`

### Analyzer 13.x API migration (24 visitor files)
- `NamedExpression` → `NamedArgument`
- `.name.label.name` → `.name.lexeme`
- `.expression` → `.argumentExpression`
- `ArgumentList<Expression>` → `NodeList<Argument>`
- `DefaultFormalParameter` → `FormalParameter.defaultClause`
- Fixed location regression in `no_equal_arguments`, `avoid_passing_async_when_sync_expected`, and `prefer_extracting_callbacks` — store the full `Argument` node (not just `argumentExpression`) to preserve correct issue offset for named arguments

### Documentation
- Updated README with Dart ≥ 3.9 (`plugins:`) and legacy (`analyzer.plugins:`) configuration examples side-by-side

## New usage (Dart ≥ 3.9)

```yaml
# analysis_options.yaml
plugins:
  dart_code_linter:
    diagnostics:
      avoid-dynamic: true
      prefer-trailing-comma: true
      no-boolean-literal-compare: true
      # … any DCL rule ID
```

## Backward compatibility

The legacy `tools/analyzer_plugin/` entry point and `analyzer.plugins` config continue to work unchanged for projects on Dart < 3.9.

Rules requiring mandatory user config (`avoid-banned-imports`, `ban-name`) are skipped by the auto-registration in the new plugin but remain available via the CLI and legacy plugin.