### PR TITLE
Add primary constructor example to prefer-static-class test

### DIFF
--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_static_class/examples/correct_example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_static_class/examples/correct_example.dart
@@ -2,7 +2,7 @@ void main() {}
 
 Future<void> main() {}
 
-class Example {
+class Example(final int primaryConstructorVariable) {
   void classMethod() {}
   static void staticClassMethod() {}
   var classVariable = 42;


### PR DESCRIPTION
I can't seem to reproduce this warning anymore. Maybe it was a UI bug. I'll adjust the test to cover the primary constructor.

Closes #272 