### PR TITLE
Cognitive Complexity: specification conformance tests, reference docs, and a working compat matrix

### DIFF
--- a/docs/cognitive-complexity/README.md
+++ b/docs/cognitive-complexity/README.md
@@ -1,0 +1,59 @@
+# Cognitive Complexity
+
+Reference material for the `cognitive-complexity` metric: what the metric is
+supposed to compute, how each rule maps onto Dart, and how far the current
+implementation conforms.
+
+| Document | Contents |
+|----------|----------|
+| [specification.md](specification.md) | The scoring rules, restated as a checklist an implementer can work from. |
+| [dart-mapping.md](dart-mapping.md) | Each rule mapped to Dart syntax, the analyzer AST node, and the code that handles it. |
+| [conformance.md](conformance.md) | What Dart Code Linter implements today, and the gaps that are pinned by tests. |
+| [examples.md](examples.md) | Worked examples with the score breakdown each one produces. |
+
+## Source
+
+Cognitive Complexity is defined by SonarSource. The normative source is the
+white paper:
+
+> G. Ann Campbell, *Cognitive Complexity: a new way of measuring
+> understandability*, version 1.7, 29 August 2023.
+> <https://www.sonarsource.com/docs/CognitiveComplexity.pdf>
+
+That paper is copyright SonarSource S.A. and is **not** reproduced here. These
+documents restate its rules in our own words for the purpose of implementing and
+testing the metric, quote only the short normative enumerations and definitions
+needed to pin behaviour, and attribute every quotation. Read the paper itself for
+the rationale behind the rules, the discussion of why Cognitive Complexity
+departs from Cyclomatic Complexity, and the extended examples. Where these
+documents and the paper disagree, the paper wins and this repository has a bug,
+either in the code or in the docs.
+
+## Why these documents exist
+
+The white paper is deliberately language-neutral. It says so directly, in the
+preamble to its specification appendix:
+
+> This is meant to be a comprehensive listing without being language-exhaustive.
+> That is, if a language has an atypical spelling for a keyword, such as `elif`
+> for `else if`, its omission here is not intended to omit it from the
+> specification.
+
+Dart has several structures the paper never names: collection-literal `if` and
+`for`, switch expressions, pattern `if-case` clauses with `when` guards. Deciding
+how those score is an act of interpretation, and that interpretation needs to be
+written down somewhere other than a pull request comment thread. That is what
+[dart-mapping.md](dart-mapping.md) is for, and [conformance.md](conformance.md)
+records which of those decisions the code has actually caught up with.
+
+## Keeping this honest
+
+Every score quoted in these documents was measured against the implementation,
+not derived by hand. The fixtures live in
+[`test/resources/cognitive_complexity_rules_example.dart`](../../test/resources/cognitive_complexity_rules_example.dart)
+and
+[`test/resources/cognitive_complexity_metric_example.dart`](../../test/resources/cognitive_complexity_metric_example.dart),
+and the assertions live in
+[`cognitive_complexity_flow_visitor_test.dart`](../../test/src/analyzers/lint_analyzer/metrics/metrics_list/cognitive_complexity/cognitive_complexity_flow_visitor_test.dart).
+If you change the visitor, those tests are the thing that tells you which of the
+numbers below moved.

--- a/docs/cognitive-complexity/conformance.md
+++ b/docs/cognitive-complexity/conformance.md
@@ -1,0 +1,95 @@
+# Conformance
+
+How far the `cognitive-complexity` metric matches
+[the specification](specification.md) today. Every row was measured against the
+implementation, not reasoned about.
+
+## Implemented and verified
+
+| Rule | Verified by |
+|------|-------------|
+| `if` structural increment plus nesting increment | `scores else and else if as hybrid increments that still raise nesting` |
+| `else if` and `else` as flat hybrid increments that still raise nesting | same test, asserts the full `1, 2, 1, 2, 1, 2` breakdown |
+| ternary increment plus nesting increment | `scores a ternary operator with a nesting increment` |
+| `for`, `for-in`, `while`, `do while` | the `sumOfPrimes` and `unlabeledJumps` tests |
+| `switch` and all its cases as a single increment | `scores a switch and all of its cases as a single increment` |
+| `catch` per clause, `try` and `finally` ignored and non-nesting | `scores every catch clause, ignoring the try and finally blocks` |
+| labeled `break` and `continue` as fundamental increments | `scores the white paper's sumOfPrimes example at 7` |
+| plain `break`, `continue` and `return` scoring nothing | `scores nothing for unlabeled break, continue and return` |
+| one increment per run of like binary logical operators | `scores each sequence of like binary logical operators once` |
+| parenthesised and negated runs counted separately | `scores a negated sequence separately from the one containing it` |
+| operator runs outside conditions | `scores a sequence of like operators outside a condition` |
+| lambdas raising nesting without being scored | `scores a closure as a nesting level rather than an increment` |
+| stacked nesting through a lambda inside a loop | `scores a closure inside a loop as two stacked nesting levels` |
+
+Tests live in
+[`cognitive_complexity_flow_visitor_test.dart`](../../test/src/analyzers/lint_analyzer/metrics/metrics_list/cognitive_complexity/cognitive_complexity_flow_visitor_test.dart),
+group `CognitiveComplexityFlowVisitor scores`. Each asserts the full
+`description: score` breakdown, not just the total, so a compensating pair of
+errors cannot pass.
+
+The strongest single check is that the white paper's own `sumOfPrimes` scores
+**7**, its published value, with the breakdown `1, 2, 3, 1`.
+
+## Known gaps
+
+Every row except the last is pinned by a test in the group
+`CognitiveComplexityFlowVisitor does not yet score`, so the current behaviour
+cannot drift unnoticed. **Update those expectations when you close a gap, do not
+delete them.** Indirect recursion is the exception: it has no fixture yet, and
+one is worth adding.
+
+| Gap | Spec says | Implementation | Cause |
+|-----|-----------|----------------|-------|
+| Switch expressions | one increment, nesting increment, raises nesting | **0** | no `visitSwitchExpression` override |
+| Collection-literal `if` and `for` | scored like their statement forms | **0** | `IfElement` and `ForElement` are never visited |
+| `when` guard of an `if-case` | the guard's operator run scores | guard invisible | `visitIfStatement` hand-walks `expression`, `thenStatement` and `elseStatement`, and omits `caseClause` |
+| Recursion cycle | `+1` per **method** in the cycle | `+1` per **call site** | counts each matching `MethodInvocation` |
+| `this.foo()` recursion | `+1` for the cycle | **0** | the check requires `node.target == null` |
+| Indirect recursion (`a` calls `b` calls `a`) | `+1` for each method | **0** (unpinned) | only self-calls by name are considered |
+
+Worked numbers for the recursion rows:
+
+```dart
+int fibonacci(int n) {
+  if (n < 2) return n;
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+// specification: 2   (if: 1, recursion cycle: 1)
+// implementation: 3  (if: 1, call: 1, call: 1)
+```
+
+```dart
+int factorial(int n) {
+  if (n <= 1) return 1;
+  return n * this.factorial(n - 1);
+}
+// specification: 2   (if: 1, recursion cycle: 1)
+// implementation: 1  (if: 1)
+```
+
+The `caseClause` gap is the one to treat as a bug rather than a missing feature:
+it drops a whole subtree from the traversal, so anything inside the clause is
+invisible, not merely unscored. A closure or a nested ternary in a guard costs
+nothing today.
+
+## Severity, in the order worth fixing
+
+1. **Switch expressions.** Idiomatic modern Dart, silently free. A metric that
+   reports zero for a real branch is worse than one that reports nothing at all.
+2. **The `caseClause` traversal.** A dropped subtree, small fix, no design
+   question.
+3. **Recursion semantics.** Needs element resolution rather than name matching to
+   do properly, which also buys indirect cycles and `this.` calls in one change.
+4. **Collection-literal `if` and `for`.** Real per the spec, but the cyclomatic
+   metric has the same blind spot, so the two should probably move together.
+
+## Neighbouring behaviour, not a gap in this metric
+
+The Cyclomatic Complexity visitor overrides `visitSwitchCase`, but under Dart 3
+a `case 1:` inside a switch **statement** parses as `SwitchPatternCase`, not the
+legacy `SwitchCase`. Only `default:` is counted, so switches are under-counted by
+that metric. The paper's `getWords` measures a Cyclomatic Complexity of 2 in this
+repository where the paper reports 4. This predates the cognitive metric and is
+tracked separately; it is recorded here because anyone comparing the two metrics
+on a switch will notice it immediately and assume the new metric is at fault.

--- a/docs/cognitive-complexity/dart-mapping.md
+++ b/docs/cognitive-complexity/dart-mapping.md
@@ -1,0 +1,136 @@
+# Mapping the rules onto Dart
+
+The white paper is language-neutral by design, and says so: its enumeration is
+"a comprehensive listing without being language-exhaustive", and a language's
+atypical spelling of a construct is still that construct. This document decides
+what that means for Dart, and points at the code.
+
+All implementation references are to
+[`cognitive_complexity_flow_visitor.dart`](../../lib/src/analyzers/lint_analyzer/metrics/metrics_list/cognitive_complexity/cognitive_complexity_flow_visitor.dart).
+
+## Direct translations
+
+These have an unambiguous Dart spelling and an unambiguous AST node.
+
+| Rule | Dart | AST node | Handled in |
+|------|------|----------|-----------|
+| `if` | `if (c) { }` | `IfStatement` | `visitIfStatement`, line 52 |
+| `else if` | `} else if (c) {` | `IfStatement` whose parent's `elseStatement` is it | `visitIfStatement`, line 52 |
+| `else` | `} else {` | `IfStatement.elseKeyword` | `visitIfStatement`, line 52 |
+| ternary | `c ? a : b` | `ConditionalExpression` | `visitConditionalExpression`, line 78 |
+| `for`, `foreach` | `for (;;)`, `for (x in xs)` | `ForStatement` (both forms) | `visitForStatement`, line 87 |
+| `while` | `while (c) { }` | `WhileStatement` | `visitWhileStatement`, line 95 |
+| `do while` | `do { } while (c);` | `DoStatement` | `visitDoStatement`, line 103 |
+| `switch` | `switch (x) { case ...: }` | `SwitchStatement` | `visitSwitchStatement`, line 111 |
+| `catch` | `catch (e)` and `on E` | `CatchClause` | `visitCatchClause`, line 123 |
+| labeled jump | `break label;`, `continue label;` | `BreakStatement`/`ContinueStatement` with a non-null `label` | lines 146 and 155 |
+| operator sequence | `&&`, `\|\|` runs | `BinaryExpression` | `visitBinaryExpression`, line 164 |
+| nested method / lambda | `(x) { }`, `() => x`, local functions | `FunctionExpression` | `visitFunctionExpression`, line 133 |
+| recursion | a self-call | `MethodInvocation` | `visitMethodInvocation`, line 181 |
+
+Two Dart details worth noting in that table:
+
+- **`for-in` is `foreach`.** Dart uses one node, `ForStatement`, for both the
+  C-style and the iterating form, distinguished by its `forLoopParts`. The paper
+  charges both identically, so one visit method covers both.
+- **`on E` without `catch`.** Dart lets you write `on StateError { }` with no
+  catch clause parameter. It is still a `CatchClause`, still one increment, and
+  the visitor falls back from `catchKeyword` to `onKeyword` to locate the
+  reported token.
+
+## Dart structures the paper never names
+
+These are the interpretation calls. Each is a construct the paper's enumeration
+covers in substance but not by name.
+
+### Collection-literal `if` and `for`
+
+```dart
+final visible = [
+  for (final item in items)
+    if (item.isVisible) item,
+];
+```
+
+These are the `for` and `if` of Appendix B, written in a position where Dart
+allows an element instead of a statement. The AST calls them `ForElement` and
+`IfElement` rather than `ForStatement` and `IfStatement`, but nothing about the
+reader's experience differs: the flow breaks, and the `if` is nested inside the
+`for`.
+
+**They should score**, exactly as their statement forms do: `+1` for the `for`,
+`+2` for the nested `if`. The paper's only exemptions are for JavaScript
+namespace functions and Python decorators; there is no comprehension exemption to
+appeal to. The rule about ignoring "structures that allow multiple statements to
+be readably shorthanded into one" is about things like `switch`, which collapses
+a chain of comparisons into one glanceable construct, not about relocating a loop
+into a literal.
+
+Not implemented today. See [conformance.md](conformance.md).
+
+### Switch expressions
+
+```dart
+final name = switch (number) {
+  1 => 'one',
+  2 => 'a couple',
+  _ => 'lots',
+};
+```
+
+A `switch` is a `switch`. Dart 3's expression form is a `SwitchExpression` node
+rather than a `SwitchStatement`, but the rule is unchanged: **one increment for
+the whole thing regardless of case count**, a nesting increment when nested, and
+it raises the nesting level for its case bodies. Guards (`when`) inside it
+contain expressions that score under the ordinary rules.
+
+Not implemented today. See [conformance.md](conformance.md).
+
+### Pattern `if-case` and `when` guards
+
+```dart
+if (value case int number when number > 0 && number < 10) { }
+```
+
+The `if` scores as any `if` does. The guard is an ordinary boolean expression, so
+its `&&` run scores `+1` as a sequence of binary logical operators, the same as
+it would in a plain condition. A guard is not itself a separate flow break: it is
+part of the one `if`.
+
+The `when` guard of a `switch` **statement** already scores correctly, because
+that traversal path goes through the base visitor. The guard of an `if-case` does
+not, because `visitIfStatement` walks its children by hand and does not include
+the case clause. See [conformance.md](conformance.md).
+
+### Recursion in a Dart-shaped world
+
+The paper charges once per method in a recursion cycle. Detecting that properly
+means resolving each call to an element and looking for cycles among the
+functions in the unit. A name-based check on unqualified calls approximates it
+but diverges in three ways: it charges per call site rather than per method, it
+misses `this.foo()`, and it misses indirect cycles. See
+[conformance.md](conformance.md).
+
+### Things that correctly score nothing
+
+Worth recording so nobody "fixes" them:
+
+- `??`, `?.`, `??=`. Cyclomatic Complexity charges for these in this codebase.
+  Cognitive Complexity is "only concerned with binary boolean operators", and
+  null-aware operators are not flow breaks a reader has to unpack. Zero.
+- `await`, `yield`, `async*`. Not branches.
+- `assert`. Not a branch in the reader's flow.
+- Plain `break`, plain `continue`, `return`, including early returns. Explicitly
+  free per the paper: an early return usually makes code clearer.
+- `try` and `finally` blocks. Ignored, and they do not raise nesting. Only
+  `catch` scores.
+- Cascades, spreads, `for` inside a string interpolation. Not control flow.
+
+## Which node a score is reported on
+
+The metric reports each increment as a `ContextMessage` anchored at a specific
+token, so the HTML and console reporters can point at the line that cost the
+points. The visitor deliberately anchors to the keyword rather than the whole
+node: `ifKeyword`, `forKeyword`, `whileKeyword`, `switchKeyword`, the `?` of a
+ternary, the operator token of a logical run. A whole-node anchor would span the
+entire body and make the report useless.

--- a/docs/cognitive-complexity/examples.md
+++ b/docs/cognitive-complexity/examples.md
@@ -1,0 +1,229 @@
+# Worked examples
+
+Every score below was produced by the implementation, not computed by hand. Most
+of the code is drawn from
+[`test/resources/cognitive_complexity_rules_example.dart`](../../test/resources/cognitive_complexity_rules_example.dart)
+and
+[`test/resources/cognitive_complexity_metric_example.dart`](../../test/resources/cognitive_complexity_metric_example.dart),
+reformatted to put each increment on the line it applies to, so any of these can
+be re-measured by running the metric tests.
+
+## The calibration pair
+
+The two functions the white paper uses to show why Cyclomatic Complexity is the
+wrong tool for readability. The paper reports a Cyclomatic Complexity of 4 for
+both.
+
+### `sumOfPrimes`, cognitive 7
+
+```dart
+int sumOfPrimes(int max) {
+  var total = 0;
+
+  outer:
+  for (var i = 1; i <= max; ++i) {     // +1
+    for (var j = 2; j < i; ++j) {      // +2  (1 + nesting 1)
+      if (i % j == 0) {                // +3  (1 + nesting 2)
+        continue outer;                // +1  (labeled jump, never nested)
+      }
+    }
+    total += i;
+  }
+
+  return total;
+}
+```
+
+This is the paper's own example, and 7 is its published value. It is the single
+most useful regression check in the suite: it exercises loop nesting, a nesting
+increment two levels deep, and the labeled-jump rule at once.
+
+### `getWords`, cognitive 1
+
+```dart
+String getWords(int number) {
+  switch (number) {   // +1, and that is the whole score
+    case 1:
+      return 'one';
+    case 2:
+      return 'a couple';
+    case 3:
+      return 'a few';
+    default:
+      return 'lots';
+  }
+}
+```
+
+The same Cyclomatic Complexity as `sumOfPrimes` by the paper's counting, one
+seventh of the Cognitive Complexity, and anyone who has read both functions
+agrees with the second number.
+
+Two caveats on the numbers here. Adding or removing cases does not move the
+Cognitive Complexity at all: the two-case variant in
+[`example/lib/src/cognitive_complexity.dart`](../../example/lib/src/cognitive_complexity.dart)
+also scores 1. And this repository currently measures a Cyclomatic Complexity of
+**2** for the function above rather than the paper's 4, because of a pre-existing
+bug in the cyclomatic visitor described at the end of
+[conformance.md](conformance.md). The cognitive number is the one being
+demonstrated here, and it is correct.
+
+## Nesting
+
+### Flat branching, cognitive 5
+
+```dart
+void flatFunction(int a) {
+  if (a == 1) {                     // +1
+  } else if (a == 2) {              // +1  (hybrid, never nested)
+  } else {                          // +1  (hybrid, never nested)
+  }
+
+  for (var i = 0; i < a; i++) {     // +1
+  }
+
+  final b = a > 0 && a < 10;        // +1  (one operator run)
+}
+```
+
+### The same structures nested, cognitive 6
+
+```dart
+void nestedFunction(int a) {
+  for (var i = 0; i < a; i++) {     // +1  (1 + nesting 0)
+    if (i == a) {                   // +2  (1 + nesting 1)
+      while (i > 0) {               // +3  (1 + nesting 2)
+        i--;
+      }
+    }
+  }
+}
+```
+
+Three structures either way. Five points flat, six points nested with one fewer
+branch, and the gap grows fast with depth. This is the whole point of the metric.
+
+### An `else if` chain with a branch in every arm, cognitive 9
+
+```dart
+void elseIfChain(int a) {
+  if (a == 1) {          // +1
+    if (a == 1) {}       // +2
+  } else if (a == 2) {   // +1  hybrid: flat, but still raises nesting
+    if (a == 2) {}       // +2
+  } else {               // +1  hybrid: flat, but still raises nesting
+    if (a == 3) {}       // +2
+  }
+}
+```
+
+The arms cost the same as each other. An `else if` is never charged a nesting
+increment for sitting inside the `if` it follows, but its body is nested exactly
+as the `then` body is.
+
+## Exceptions, cognitive 8
+
+```dart
+void catchClauses(int a) {
+  try {
+    if (a > 0) {}        // +1  try does not raise nesting
+  } on StateError {      // +1
+    if (a > 0) {}        // +2
+  } catch (e) {          // +1
+    if (a > 0) {}        // +2
+  } finally {
+    if (a > 0) {}        // +1  finally does not raise nesting
+  }
+}
+```
+
+Both clause forms score, `on E` and `catch (e)` alike. The `try` and `finally`
+blocks contribute nothing themselves and leave the nesting level alone, which is
+why the first and last `if` cost 1 while the two inside the clauses cost 2.
+
+## Closures
+
+```dart
+void closureNesting(List<int> numbers) {
+  numbers.forEach((number) {   // +0, but nesting is now 1
+    if (number > 0) {}         // +2
+  });
+}                              // total 2
+
+void closureInsideLoop(List<int> numbers) {
+  for (final number in numbers) {  // +1
+    numbers.forEach((other) {      // +0, but nesting is now 2
+      if (other > 0) {}            // +3
+    });
+  }
+}                                  // total 4
+```
+
+The lambda is never charged. It only raises the ceiling for what it contains,
+which is why callback-heavy code scores higher than it looks like it should.
+
+## Boolean operators
+
+```dart
+// cognitive 4
+if (a && b && c || d || e && f) { }
+//  +1 if, +1 for the || run, +1 for `a && b && c`, +1 for `e && f`
+
+// cognitive 3
+if (a && !(b && c)) { }
+//  +1 if, +1 for the outer run, +1 for the parenthesised run
+
+// cognitive 1
+bool operatorSequenceInReturn(bool a, bool b, bool c) => a && b && c;
+//  one run, and it counts even outside a condition
+```
+
+Both `if` examples are the paper's, reproduced at its published values. Length
+within a run is free; mixing operators, or parenthesising, starts a new run and
+costs a point.
+
+## Free of charge
+
+```dart
+void unlabeledJumps(List<int> numbers) {
+  for (final number in numbers) {   // +1
+    if (number < 0) {               // +2
+      continue;                     // +0  unlabeled
+    }
+    if (number > 10) {              // +2
+      break;                        // +0  unlabeled
+    }
+  }
+
+  return;                           // +0
+}                                   // total 5
+```
+
+Compare with `sumOfPrimes` above, where the `continue outer` costs a point
+precisely because the reader has to go and find the label.
+
+## Currently unscored
+
+These are gaps, not rules. They are listed here so the numbers in this document
+are not mistaken for correct behaviour. See [conformance.md](conformance.md).
+
+```dart
+// scored 0, should be 4 (+1 for, +2 nested if, +1 for the trailing if)
+List<int> collectionLiteralControlFlow(List<int> numbers, bool flag) => [
+      for (final number in numbers)
+        if (number > 0) number,
+      if (flag) 0,
+    ];
+
+// scored 0, should be 1
+String switchExpression(int number) => switch (number) {
+      1 => 'one',
+      2 => 'a couple',
+      _ => 'lots',
+    };
+
+// scored 1, should be 2: the guard's `&&` run is never walked
+void ifCaseGuard(Object value) {
+  if (value case int number when number > 0 && number < 10) {}
+}
+```

--- a/docs/cognitive-complexity/specification.md
+++ b/docs/cognitive-complexity/specification.md
@@ -1,0 +1,164 @@
+# The scoring rules
+
+Restated from SonarSource's Cognitive Complexity white paper, version 1.7. See
+[README.md](README.md) for the source and the terms under which this summary
+exists. For the reasoning behind each rule, read the paper.
+
+## The idea in one paragraph
+
+Cyclomatic Complexity counts execution paths, which makes it a good measure of
+how many tests a function needs and a poor measure of how hard the function is to
+read. Cognitive Complexity drops the path-counting model. It scores a function by
+walking its control flow and charging for each break in the reader's linear
+top-to-bottom flow, charging more when those breaks are nested inside one
+another, and charging nothing for structures that compress many statements into
+one readable shorthand. A `switch` with ten cases is one charge, because a reader
+takes it in at a glance. Three `if`s nested three deep is six, because the reader
+has to hold each enclosing condition in their head.
+
+## The three basic rules
+
+1. Ignore structures that allow multiple statements to be readably shorthanded
+   into one.
+2. Increment (add one) for each break in the linear flow of the code.
+3. Increment when flow-breaking structures are nested.
+
+## The four kinds of increment
+
+| Kind | Scored? | Raises nesting? | Applies to |
+|------|---------|-----------------|------------|
+| **Structural** | yes, `1 + nesting` | yes | `if`, ternary, loops, `switch`, `catch` |
+| **Nesting** | the `+ nesting` part of the above | n/a | the same structures, once nested |
+| **Fundamental** | yes, always `+1` | no | labeled jumps, operator sequences, recursion |
+| **Hybrid** | yes, always `+1` | yes | `else`, `else if` |
+
+The hybrid kind is the one that catches people out. `else` and `else if` are
+charged a flat `+1` no matter how deeply nested they are, because, in the paper's
+words, "the mental cost has already been paid when reading the `if`". But they
+still raise the nesting level for whatever they contain, so an `if` inside an
+`else` block costs the same as an `if` inside the matching `then` block.
+
+## Increments
+
+There is an increment for each of the following:
+
+- `if`, `else if`, `else`, ternary operator
+- `switch`
+- `for`, `foreach`
+- `while`, `do while`
+- `catch`
+- `goto LABEL`, `break LABEL`, `continue LABEL`, `break NUMBER`, `continue NUMBER`
+- sequences of binary logical operators
+- each method in a recursion cycle
+
+## Nesting level
+
+The following structures raise the nesting level of everything inside them:
+
+- `if`, `else if`, `else`, ternary operator
+- `switch`
+- `for`, `foreach`
+- `while`, `do while`
+- `catch`
+- nested methods and method-like structures such as lambdas
+
+## Nesting increments
+
+The following receive a nesting increment proportional to how deep inside
+nesting-level structures they sit:
+
+- `if`, ternary operator
+- `switch`
+- `for`, `foreach`
+- `while`, `do while`
+- `catch`
+
+Note what is absent from this third list but present in the first two: `else`,
+`else if` (hybrid, flat `+1`), and lambdas (raise nesting, are never scored
+themselves).
+
+## Rules that need spelling out
+
+### Switches
+
+A `switch` and all of its cases combined incur a single structural increment. The
+number of cases is irrelevant. This is the sharpest departure from Cyclomatic
+Complexity, which charges per case, and it is deliberate: a `switch` compares one
+variable against a set of literals, while an equivalent `if`/`else if` chain may
+compare any number of variables using any number of operators.
+
+### Catches
+
+Each `catch` clause is one structural increment, no matter how many exception
+types it catches. `try` and `finally` blocks are ignored altogether, and neither
+raises the nesting level. So an `if` directly inside a `try` costs 1, while the
+same `if` inside the `catch` costs 2.
+
+### Sequences of binary logical operators
+
+Not one increment per operator. One increment per *run of like operators*.
+Understanding `a && b && c && d` is barely harder than understanding `a && b`,
+but `a || b && c || d` is markedly harder than either, so mixing is what gets
+charged. Parentheses break a run. The paper's two examples:
+
+```
+if (a          // +1 for `if`
+    && b && c  // +1
+    || d || e  // +1
+    && f)      // +1   -> 4
+
+if (a          // +1 for `if`
+    &&         // +1
+    !(b && c)) // +1   -> 3
+```
+
+This applies everywhere binary boolean operators appear, not just in conditions:
+assignments, arguments and return statements are all scored.
+
+### Recursion
+
+One fundamental increment for **each method in a recursion cycle**, direct or
+indirect. Not one per call site. A method that calls itself twice is charged
+once; two methods that call each other are charged once each. Recursion is a kind
+of meta-loop, and Cognitive Complexity charges for loops.
+
+### Jumps to labels
+
+`goto`, and `break`/`continue` to a label or to a level number, are fundamental
+increments. Plain `break`, plain `continue` and early `return` are free, "because
+an early return can often make code much clearer".
+
+### Nested functions and lambdas
+
+A nested function or lambda is never itself scored, but it raises the nesting
+level for its body. A branch inside a callback inside a loop is charged for both
+enclosing levels.
+
+## Compensating usages
+
+The paper carves out exactly two language-specific exemptions, neither of which
+applies to Dart:
+
+- **JavaScript**: an outer function used purely as a namespace, containing only
+  declarations at the top level, is ignored and does not raise nesting.
+- **Python**: a decorator, narrowly defined as a function containing only a
+  nested function and a `return`, is ignored and does not raise nesting.
+
+There is no exemption for comprehensions, collection literals, or any other
+compressed control-flow syntax. That matters for Dart and is worked through in
+[dart-mapping.md](dart-mapping.md).
+
+## Reference values
+
+Two functions from the paper, used throughout as calibration. By the paper's
+counting both have a Cyclomatic Complexity of 4, which is the point: the metric
+that scores them equally is not measuring readability.
+
+| Function | Cognitive | Why |
+|----------|-----------|-----|
+| `sumOfPrimes`, two nested loops around an `if` with a labeled `continue` | **7** | 1 + 2 + 3 + 1 |
+| `getWords`, a `switch` with three cases and a default | **1** | the whole switch is one increment |
+
+Dart Code Linter reproduces both cognitive values. See
+[examples.md](examples.md), which also notes why it does not reproduce the
+cyclomatic ones.

--- a/extension/mcp/resources/metrics_reference.md
+++ b/extension/mcp/resources/metrics_reference.md
@@ -21,6 +21,7 @@ Measures how difficult a function is for a human to read and understand, based o
 - **Config key:** `cognitive-complexity`
 - **Default threshold:** 20
 - **Measured on:** Functions and methods
+- **Scoring rules:** see `docs/cognitive-complexity/`
 
 ### Lines of Code (LOC)
 

--- a/lib/src/analyzers/lint_analyzer/metrics/metrics_list/cognitive_complexity/cognitive_complexity_metric.dart
+++ b/lib/src/analyzers/lint_analyzer/metrics/metrics_list/cognitive_complexity/cognitive_complexity_metric.dart
@@ -26,6 +26,9 @@ const _documentation = MetricDocumentation(
 /// human to read and understand, based on SonarSource's Cognitive Complexity
 /// algorithm. Unlike cyclomatic complexity, it penalizes control flow that
 /// is nested more heavily than the same control flow written flat.
+///
+/// The scoring rules, how they map onto Dart, and the gaps the implementation
+/// still has are documented in `docs/cognitive-complexity/`.
 class CognitiveComplexityMetric extends FunctionMetric<int> {
   static const String metricId = 'cognitive-complexity';
 

--- a/scripts/test_analyzer_compat.py
+++ b/scripts/test_analyzer_compat.py
@@ -20,22 +20,80 @@ from pathlib import Path
 # analyzer major spanned by the pubspec range (>=10.0.0 <15.0.0), plus a second
 # 13.x row to straddle the namePart reshape (see the 13.3.0 entry).
 # Each entry: (analyzer_version, analyzer_plugin_version, extra_overrides).
-# `extra_overrides` lets us pin test/test_core/test_api when a given analyzer
-# version requires a newer test stack than the lowest-allowed by pubspec.
+# `extra_overrides` pins whatever else a row needs on top of the analyzer pair.
+
+# The test runner stack, pinned on every row rather than left to resolution:
+# pubspec.lock is gitignored, so an unpinned row inherits whatever lock happens
+# to be lying around, and a clean checkout fails inside test_core itself, which
+# looks nothing like a code regression.
+#
+# There is no slack in the value. test_core 0.6.18 is both the floor (analyzer
+# 13+ fails on NodeList<Argument> below it) and the ceiling (0.6.19 fails against
+# analyzer 10 with "'NamedArgument' isn't a type"), so a bump breaks one end.
+TEST_STACK = {
+    "test": "1.31.1",
+    "test_core": "0.6.18",
+    "test_api": "0.7.12",
+}
+
+# dart_style is a transitive dependency of analyzer_plugin
+# (`change_builder_dart.dart`, used by fix-producing rules), and each
+# dart_style release exact-brackets the analyzer AST shape it compiles
+# against (e.g. 3.1.7 declares `analyzer: '>=10.0.0 <12.0.0'`). Overriding
+# `analyzer` via dependency_overrides does not make pub re-check dart_style's
+# own constraint against it, so an unpinned dart_style silently keeps
+# whatever version the ambient lockfile already holds even when it no longer
+# supports the row's analyzer. That mismatch only breaks the build once
+# something actually compiles dart_style's visitor code (the modern
+# analysis_server_plugin bridge in dcl_analysis_rule.dart reaches every
+# rule's fix-building code, which reaches change_builder_dart.dart), so every
+# row must pin a dart_style compatible with its own analyzer version.
+_DART_STYLE_BY_ANALYZER = {
+    "10.0.1": "3.1.6",  # ^10.0.0
+    "11.0.0": "3.1.7",  # >=10.0.0 <12.0.0
+    "12.1.0": "3.1.8",  # ^12.0.0
+    "13.0.0": "3.1.9",  # ^13.0.0
+    "13.3.0": "3.1.9",
+    "14.0.0": "3.1.11",  # >=13.1.0 <15.0.0
+    "14.1.0": "3.1.12",
+}
+
 VERSION_PAIRS = [
     # 10.x: the pubspec floor. .0.1 patch is the lowest that resolves with meta 1.17.0.
-    ("10.0.1", "0.14.1", {"analysis_server_plugin": "0.3.7"}),
-    ("11.0.0", "0.14.5", {"analysis_server_plugin": "0.3.11"}),  # 11.x
-    ("12.1.0", "0.14.8", {"analysis_server_plugin": "0.3.14"}),  # 12.x
+    (
+        "10.0.1",
+        "0.14.1",
+        {
+            **TEST_STACK,
+            "analysis_server_plugin": "0.3.7",
+            "dart_style": _DART_STYLE_BY_ANALYZER["10.0.1"],
+        },
+    ),
+    (
+        "11.0.0",  # 11.x
+        "0.14.5",
+        {
+            **TEST_STACK,
+            "analysis_server_plugin": "0.3.11",
+            "dart_style": _DART_STYLE_BY_ANALYZER["11.0.0"],
+        },
+    ),
+    (
+        "12.1.0",  # 12.x
+        "0.14.8",
+        {
+            **TEST_STACK,
+            "analysis_server_plugin": "0.3.14",
+            "dart_style": _DART_STYLE_BY_ANALYZER["12.1.0"],
+        },
+    ),
     (
         "13.0.0",
         "0.14.9",
         {
+            **TEST_STACK,
             "analysis_server_plugin": "0.3.15",
-            # analyzer 13 needs the bumped test stack (NodeList<Argument>).
-            "test": "1.31.1",
-            "test_core": "0.6.18",
-            "test_api": "0.7.12",
+            "dart_style": _DART_STYLE_BY_ANALYZER["13.0.0"],
         },
     ),
     (
@@ -47,26 +105,32 @@ VERSION_PAIRS = [
         "13.3.0",
         "0.14.12",
         {
+            **TEST_STACK,
             "analysis_server_plugin": "0.3.18",
-            "test": "1.31.1",
-            "test_core": "0.6.18",
-            "test_api": "0.7.12",
+            "dart_style": _DART_STYLE_BY_ANALYZER["13.3.0"],
         },
     ),
     (
         # 14.x requires dart_style 3.1.11+ (transitive via analyzer_plugin),
-        # which only just added analyzer-14 support. dart_style itself isn't
-        # pinned here; pub resolves it automatically off analyzer_plugin.
+        # which only just added analyzer-14 support.
         "14.0.0",
         "0.14.13",
-        {"analysis_server_plugin": "0.3.19"},
+        {
+            **TEST_STACK,
+            "analysis_server_plugin": "0.3.19",
+            "dart_style": _DART_STYLE_BY_ANALYZER["14.0.0"],
+        },
     ),
     (
         # Upper boundary of the current <15.0.0 ceiling: latest 14.x patch,
         # which is what `dart pub upgrade` actually resolves to today.
         "14.1.0",
         "0.14.14",
-        {"analysis_server_plugin": "0.3.20"},
+        {
+            **TEST_STACK,
+            "analysis_server_plugin": "0.3.20",
+            "dart_style": _DART_STYLE_BY_ANALYZER["14.1.0"],
+        },
     ),
 ]
 

--- a/test/resources/cognitive_complexity_metric_example.dart
+++ b/test/resources/cognitive_complexity_metric_example.dart
@@ -5,26 +5,26 @@ void flatFunction(int a) {
   if (a == 1) {
     // +1
   } else if (a == 2) {
-    // +1
+    // +1 (hybrid increment: no nesting bonus of its own)
   } else {
-    // +1
+    // +1 (hybrid increment: no nesting bonus of its own)
   }
 
   for (var i = 0; i < a; i++) {
     // +1
   }
 
-  final b = a > 0 && a < 10;
+  final b = a > 0 && a < 10; // +1 for the sequence of like operators
 }
 
 // nested function: an if inside a for, each nesting level adds its own bonus
 void nestedFunction(int a) {
   for (var i = 0; i < a; i++) {
-    // +2 (base 1 + nesting level 1)
+    // +1 (base 1 + nesting level 0)
     if (i == a) {
-      // +3 (base 1 + nesting level 2)
+      // +2 (base 1 + nesting level 1)
       while (i > 0) {
-        // +4 (base 1 + nesting level 3)
+        // +3 (base 1 + nesting level 2)
         i--;
       }
     }

--- a/test/resources/cognitive_complexity_rules_example.dart
+++ b/test/resources/cognitive_complexity_rules_example.dart
@@ -1,0 +1,205 @@
+// ignore_for_file: unused_local_variable, no-empty-block
+
+// Fixtures for the individual scoring rules of SonarSource's Cognitive
+// Complexity specification (white paper v1.7, Appendix B). Each function is
+// annotated with the increment the specification assesses for every structure,
+// so the expected totals in the tests can be checked against the paper.
+
+// B1 switch: "A switch and all its cases combined incurs a single structural
+// increment", and the cases raise the nesting level for what they contain.
+String switchStatement(int number) {
+  switch (number) {
+    // +1
+    case 1:
+      return 'one';
+    case 2:
+      return 'a couple';
+    default:
+      if (number > 3) {
+        // +2 (base 1 + nesting 1)
+        return 'lots';
+      }
+
+      return 'a few';
+  }
+}
+
+// B1 catch: "each catch clause results in a structural increment [...] try and
+// finally blocks are ignored altogether".
+void catchClauses(int a) {
+  try {
+    if (a > 0) {} // +1 (try does not raise the nesting level)
+  } on StateError {
+    // +1
+    if (a > 0) {} // +2 (base 1 + nesting 1)
+  } catch (e) {
+    // +1
+    if (a > 0) {} // +2 (base 1 + nesting 1)
+  } finally {
+    if (a > 0) {} // +1 (finally does not raise the nesting level)
+  }
+}
+
+// B3 ternary operator: subject to a nesting increment like an if.
+int ternaryOperator(int a) => a > 0
+    ? a > 5
+        ? 1 // the inner ternary is +2 (base 1 + nesting 1)
+        : 2
+    : 3; // the outer ternary is +1
+
+// B1 jumps to labels, taken verbatim from the white paper's canonical example.
+// The paper scores this function at 7.
+int sumOfPrimes(int max) {
+  var total = 0;
+
+  outer:
+  for (var i = 1; i <= max; ++i) {
+    // +1
+    for (var j = 2; j < i; ++j) {
+      // +2 (base 1 + nesting 1)
+      if (i % j == 0) {
+        // +3 (base 1 + nesting 2)
+        continue outer; // +1 (a labeled jump, never a nesting increment)
+      }
+    }
+    total += i;
+  }
+
+  return total;
+}
+
+// "no other jumps or early exits cause an increment": unlabeled break,
+// unlabeled continue and return are free.
+void unlabeledJumps(List<int> numbers) {
+  for (final number in numbers) {
+    // +1
+    if (number < 0) {
+      // +2 (base 1 + nesting 1)
+      continue; // +0
+    }
+    if (number > 10) {
+      // +2 (base 1 + nesting 1)
+      break; // +0
+    }
+  }
+
+  return; // +0
+}
+
+// B2 "nested methods and method-like structures such as lambdas" raise the
+// nesting level without being scored themselves.
+void closureNesting(List<int> numbers) {
+  numbers.forEach((number) {
+    // +0, but the nesting level is now 1
+    if (number > 0) {} // +2 (base 1 + nesting 1)
+  });
+}
+
+void closureInsideLoop(List<int> numbers) {
+  for (final number in numbers) {
+    // +1
+    numbers.forEach((other) {
+      // +0, but the nesting level is now 2
+      if (other > 0) {} // +3 (base 1 + nesting 2)
+    });
+  }
+}
+
+// Hybrid increments: else and else if are scored +1 with no nesting increment
+// of their own, "but which do increase the nesting count" for their bodies.
+void elseIfChain(int a) {
+  if (a == 1) {
+    // +1
+    if (a == 1) {} // +2 (base 1 + nesting 1)
+  } else if (a == 2) {
+    // +1 (hybrid: no nesting increment)
+    if (a == 2) {} // +2 (base 1 + nesting 1)
+  } else {
+    // +1 (hybrid: no nesting increment)
+    if (a == 3) {} // +2 (base 1 + nesting 1)
+  }
+}
+
+// "Cognitive complexity increments for each new sequence of like operators".
+// Both conditions below are taken verbatim from the white paper, which scores
+// the first at 4 and the second at 3:
+//
+//   if (a          // +1 for `if`
+//       && b && c  // +1
+//       || d || e  // +1
+//       && f)      // +1
+//
+//   if (a          // +1 for `if`
+//       &&         // +1
+//       !(b && c)) // +1
+bool mixedOperatorSequences(bool a, bool b, bool c, bool d, bool e, bool f) {
+  if (a && b && c || d || e && f) {
+    return true;
+  }
+
+  return false;
+}
+
+bool negatedOperatorSequence(bool a, bool b, bool c) {
+  if (a && !(b && c)) {
+    return true;
+  }
+
+  return false;
+}
+
+// A sequence of like operators outside a condition is still scored: the paper
+// increments "for all sequences of binary boolean operators such as those in
+// variable assignments, method invocations, and return statements".
+bool operatorSequenceInReturn(bool a, bool b, bool c) => a && b && c; // +1
+
+// Dart's collection-literal `if` and `for` are the same control flow structures
+// as their statement forms, so Appendix B assesses increments for them. The
+// visitor does not score them today, and this fixture pins that gap.
+List<int> collectionLiteralControlFlow(List<int> numbers, bool flag) => [
+      for (final number in numbers) // expected +1, scored 0 today
+        if (number > 0) number, // expected +2, scored 0 today
+      if (flag) 0, // expected +1, scored 0 today
+    ];
+
+// Dart 3 switch expressions are switches, so Appendix B assesses an increment
+// for them. The visitor does not score them today, and this fixture pins that
+// gap.
+String switchExpression(int number) => switch (number) {
+      1 => 'one', // expected +1 for the switch as a whole, scored 0 today
+      2 => 'a couple',
+      _ => 'lots',
+    };
+
+// A pattern `if-case` with a `when` guard. The guard's operator sequence is
+// expected to be scored, but the visitor never walks the case clause today.
+void ifCaseGuard(Object value) {
+  if (value case int number when number > 0 && number < 10) {
+    // +1 for the if, and the `&&` sequence is expected to add +1
+    final matched = number;
+  }
+}
+
+// Two recursive call sites in the same method. The specification assesses a
+// fundamental increment "for each method in a recursion cycle", not for each
+// call, so the expected score is one increment.
+int fibonacci(int n) {
+  if (n < 2) {
+    // +1
+    return n;
+  }
+
+  return fibonacci(n - 1) + fibonacci(n - 2); // expected +1 for the cycle
+}
+
+// Recursion through an explicit `this` receiver.
+class Recursive {
+  int factorial(int n) {
+    if (n <= 1) {
+      // +1
+      return 1;
+    }
+
+    return n * this.factorial(n - 1); // expected +1 for the cycle
+  }
+}

--- a/test/src/analyzers/lint_analyzer/metrics/metrics_list/cognitive_complexity/cognitive_complexity_flow_visitor_test.dart
+++ b/test/src/analyzers/lint_analyzer/metrics/metrics_list/cognitive_complexity/cognitive_complexity_flow_visitor_test.dart
@@ -8,8 +8,12 @@ import '../../../../../helpers/file_resolver.dart';
 const _examplePath =
     './test/resources/cognitive_complexity_metric_example.dart';
 
+const _rulesExamplePath =
+    './test/resources/cognitive_complexity_rules_example.dart';
+
 Future<void> main() async {
   final result = await FileResolver.resolve(_examplePath);
+  final rulesResult = await FileResolver.resolve(_rulesExamplePath);
 
   group(
     'CognitiveComplexityFlowVisitor collect information about cognitive complexity in',
@@ -80,4 +84,183 @@ Future<void> main() async {
       });
     },
   );
+
+  group('CognitiveComplexityFlowVisitor scores', () {
+    final scopeVisitor = ScopeVisitor();
+    rulesResult.unit.visitChildren(scopeVisitor);
+
+    test('a switch and all of its cases as a single increment', () {
+      expect(
+        _scoresOf(scopeVisitor, 'switchStatement'),
+        equals(['Switch statement: 1', 'If statement: 2']),
+      );
+    });
+
+    test('every catch clause, ignoring the try and finally blocks', () {
+      expect(
+        _scoresOf(scopeVisitor, 'catchClauses'),
+        equals([
+          'If statement: 1',
+          'Catch clause: 1',
+          'If statement: 2',
+          'Catch clause: 1',
+          'If statement: 2',
+          'If statement: 1',
+        ]),
+      );
+    });
+
+    test('a ternary operator with a nesting increment', () {
+      expect(
+        _scoresOf(scopeVisitor, 'ternaryOperator'),
+        equals(['Conditional expression: 1', 'Conditional expression: 2']),
+      );
+    });
+
+    test("the white paper's sumOfPrimes example at 7", () {
+      expect(
+        _scoresOf(scopeVisitor, 'sumOfPrimes'),
+        equals([
+          'For statement: 1',
+          'For statement: 2',
+          'If statement: 3',
+          'Labeled continue statement: 1',
+        ]),
+      );
+      expect(_complexityOf(scopeVisitor, 'sumOfPrimes'), equals(7));
+    });
+
+    test('nothing for unlabeled break, continue and return', () {
+      expect(
+        _scoresOf(scopeVisitor, 'unlabeledJumps'),
+        equals(['For statement: 1', 'If statement: 2', 'If statement: 2']),
+      );
+    });
+
+    test('a closure as a nesting level rather than an increment', () {
+      expect(
+        _scoresOf(scopeVisitor, 'closureNesting'),
+        equals(['If statement: 2']),
+      );
+    });
+
+    test('a closure inside a loop as two stacked nesting levels', () {
+      expect(
+        _scoresOf(scopeVisitor, 'closureInsideLoop'),
+        equals(['For statement: 1', 'If statement: 3']),
+      );
+    });
+
+    test('else and else if as hybrid increments that still raise nesting', () {
+      expect(
+        _scoresOf(scopeVisitor, 'elseIfChain'),
+        equals([
+          'If statement: 1',
+          'If statement: 2',
+          'Else if statement: 1',
+          'If statement: 2',
+          'Else statement: 1',
+          'If statement: 2',
+        ]),
+      );
+    });
+
+    test('each sequence of like binary logical operators once', () {
+      expect(
+        _scoresOf(scopeVisitor, 'mixedOperatorSequences'),
+        equals([
+          'If statement: 1',
+          'Operator ||: 1',
+          'Operator &&: 1',
+          'Operator &&: 1',
+        ]),
+      );
+    });
+
+    test('a negated sequence separately from the one containing it', () {
+      expect(
+        _scoresOf(scopeVisitor, 'negatedOperatorSequence'),
+        equals(['If statement: 1', 'Operator &&: 1', 'Operator &&: 1']),
+      );
+    });
+
+    test('a sequence of like operators outside a condition', () {
+      expect(
+        _scoresOf(scopeVisitor, 'operatorSequenceInReturn'),
+        equals(['Operator &&: 1']),
+      );
+    });
+  });
+
+  // The specification assesses increments for these structures, so every
+  // expectation below pins a known gap rather than the intended behaviour.
+  // Each one should be updated, not deleted, once the gap is closed.
+  group('CognitiveComplexityFlowVisitor does not yet score', () {
+    final scopeVisitor = ScopeVisitor();
+    rulesResult.unit.visitChildren(scopeVisitor);
+
+    test('collection-literal if and for', () {
+      expect(
+        _complexityOf(scopeVisitor, 'collectionLiteralControlFlow'),
+        equals(0),
+      );
+    });
+
+    test('a switch expression', () {
+      expect(_complexityOf(scopeVisitor, 'switchExpression'), equals(0));
+    });
+
+    test('the guard of an if-case clause', () {
+      expect(
+        _scoresOf(scopeVisitor, 'ifCaseGuard'),
+        equals(['If statement: 1']),
+      );
+    });
+
+    test('a recursion cycle once instead of once per call site', () {
+      expect(
+        _scoresOf(scopeVisitor, 'fibonacci'),
+        equals(['If statement: 1', 'Recursive call: 1', 'Recursive call: 1']),
+      );
+    });
+
+    test('a recursive call made through an explicit this', () {
+      expect(
+        _scoresOf(scopeVisitor, 'factorial'),
+        equals(['If statement: 1']),
+      );
+    });
+  });
+}
+
+CognitiveComplexityFlowVisitor _visitorFor(ScopeVisitor scope, String name) {
+  final declaration = scope.functions
+      .map((function) => function.declaration)
+      .firstWhere((declaration) => _nameOf(declaration) == name);
+
+  final visitor = CognitiveComplexityFlowVisitor(
+    root: declaration,
+    functionName: name,
+  );
+  declaration.visitChildren(visitor);
+
+  return visitor;
+}
+
+Iterable<String> _scoresOf(ScopeVisitor scope, String name) => _visitorFor(
+      scope,
+      name,
+    ).scoredEntities.map((entity) => '${entity.description}: ${entity.score}');
+
+int _complexityOf(ScopeVisitor scope, String name) =>
+    _visitorFor(scope, name).complexity;
+
+String? _nameOf(Declaration declaration) {
+  if (declaration is FunctionDeclaration) {
+    return declaration.name.lexeme;
+  } else if (declaration is MethodDeclaration) {
+    return declaration.name.lexeme;
+  }
+
+  return null;
 }


### PR DESCRIPTION
Additive contribution to `feat/cognitive-complexity`, not a replacement for anything in it. The
algorithm in that branch is sound: I verified it rule by rule against SonarSource's white paper
(v1.7) and it reproduces the paper's canonical `sumOfPrimes` at its published value of 7.

**The only change to `lib/` in this PR is a three-line dartdoc comment.** No behaviour change, no
API change, nothing that can move a reported metric value. Everything else is tests, docs and the
compat harness.

## What this adds

**`test(cognitive-complexity)`** — a fixture with one function per rule of Appendix B, and 16 tests
that assert the full `description: score` breakdown rather than just the total (9 tests to 25 in
that directory; suite 685 to 701).

The `scores` group covers what was implemented but untested: switch, catch, ternary nesting,
labeled jumps, closure nesting, else/else-if hybrid increments, and the like-operator sequence
rule. It includes the paper's own `sumOfPrimes` (7) and both of its operator-sequence conditions
(4 and 3), so the suite now checks conformance against published reference values.

A second `does not yet score` group pins five deviations from the spec so they cannot drift
silently. Those expectations should be **updated, not deleted**, when the gaps close.

**`docs(cognitive-complexity)`** — `docs/cognitive-complexity/`: the scoring rules, how each maps
onto Dart syntax and the analyzer AST, a conformance table keyed to test names, and worked
examples. The paper is language-neutral by design, so the Dart-specific calls it does not make
(collection-literal `if`/`for`, switch expressions, if-case guards) needed writing down somewhere
durable. The paper is copyright SonarSource and is not reproduced; the docs restate its rules,
quote only the short normative enumerations, and link to the source.

**`build(compat)`** — backports `scripts/test_analyzer_compat.py` verbatim from trunk (`ee53c113`),
which this branch predates. Without it the full matrix fails on rows 10.0.1, 11.0.0, 12.1.0 and
13.0.0 while loading the analysis_server_plugin test, with a compile error inside `dart_style`
itself. It will vanish from this diff on your next trunk sync.

## Verification

- `make test-analyzer-compat-full`: **all 7 rows green**, 701 tests each (analyzer 10.0.1 through
  14.1.0). This is the first full-matrix pass the branch can produce.
- `dart analyze`: no new issues.
- `dart format`: clean.

## Findings for you to decide on

1. **The PR description says cyclomatic 3 in the Changes section and 4 in the code comment.**
   Measured 4, twice, at both visitor and metric level. Two `for` plus one `if` plus the base.

2. **`example/lib/src/cognitive_complexity.dart` does not match the canonical example.** It scores
   6, not the paper's 7, because the labeled `continue OUT` became a plain `break`. That drops
   exactly the +1 that demonstrates the labeled-jump rule the visitor implements. Restoring the
   label would fix both the score and the "matches SonarSource's canonical example" claim.

3. **The same example throws if executed.** The inner loop starts at `j = 0` and evaluates
   `i % j`. The paper starts at `j = 2`. `total += 1` also does not sum primes; the paper uses
   `total += i`.

4. **Five spec gaps**, all pinned by tests and detailed in `docs/cognitive-complexity/conformance.md`:
   Dart 3 switch expressions score 0; collection-literal `if`/`for` score 0; the `when` guard of an
   if-case is never walked (`visitIfStatement` hand-walks its children and omits `caseClause`, so
   the whole subtree is invisible, not merely unscored); recursion increments per call site rather
   than once per cycle, and misses `this.`-qualified and indirect recursion.

   I would treat the switch expression and the `caseClause` traversal as worth fixing before merge:
   both are silent zeros on idiomatic modern Dart, and a metric that reports 0 for a real branch is
   worse than one that reports nothing.

5. **Adjacent, pre-existing, not from this branch:** the cyclomatic visitor overrides
   `visitSwitchCase`, but under Dart 3 `case 1:` parses as `SwitchPatternCase`. Only `default:` is
   counted, so every switch in every Dart 3 codebase is under-counted by that metric. The paper's
   `getWords` measures cyclomatic 2 here where the paper reports 4. Probably deserves its own issue.
